### PR TITLE
Add TAURI_SIGNING_PRIVATE_KEY to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,5 +34,5 @@
 # EXA_API_KEY=
 # EXA_API_URL=https://api.exa.ai
 
-# Set tauri update signing key
+# Set tauri update signing key to build desktop app locally
 # TAURI_SIGNING_PRIVATE_KEY=key


### PR DESCRIPTION
I wrote an entire script to set this because I kept forgetting to set it and then I would wait 10 minutes for Pipali to build only to have to run it all over again because this wasn't set.  I think it would be simpler to have this variable in the `.env.example` file so it can be se once and then the dev can just keep rebuilding it even after a reboot without having to reset the env variable.  This should fix #9 