### PR TITLE
Document setting Tauri signing key to build Desktop app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,5 +34,5 @@
 # EXA_API_KEY=
 # EXA_API_URL=https://api.exa.ai
 
-# Set tauri update signing key to build desktop app locally (Set BEFORE building desktop app)
+# Set tauri update signing key to build desktop app locally
 # TAURI_SIGNING_PRIVATE_KEY=key

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,32 +20,12 @@ Open [http://localhost:6464](http://localhost:6464) in your browser.
 
 ### Desktop App
 
-#### Don't forget to set TAURI_SIGNING_PRIVATE_KEY
-
-Pipali uses [Tauri](https://v2.tauri.app/) for it's desktop. Tauri uses [signed updates](https://v2.tauri.app/plugin/updater/#signing-updates) with the [Tauri Updater](https://v2.tauri.app/plugin/updater/#_top).  The Tauri Updater uses an environment variable that must be set **BEFORE** you build Pipali!
-
-#### Setting TAURI_SIGNING_PRIVATE_KEY
-
-##### .env (recommended)
-
-Setting the variable in a `.env` file is the recommended way to do it so you don't have to keep setting it each development session.
-
-Copy `.env.example` into a file named `.env` if you haven't already and set `TAURI_SIGNING_PRIVATE_KEY` to the key you [generated](https://v2.tauri.app/reference/cli/#signer-generate) using Tauri CLI.
-
-##### Using export
-
-Using `export` you can run:
-```shell
-export TAURI_SIGNING_PRIVATE_KEY=you_key_here
-```
-The downside to this is you will have to set it each time you re-open your terminal.
-
-
-Build the Tauri desktop app (requires [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/)):
-
-```bash
-bun run tauri:build:debug
-```
+1. Setup [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/)
+2. [Generate](https://v2.tauri.app/reference/cli/#signer-generate) a signing key and set `TAURI_SIGNING_PRIVATE_KEY` env var in .env file or shell export. See [Tauri signed updates](https://v2.tauri.app/plugin/updater/#signing-updates)
+3. Build the Tauri desktop app:
+   ```bash
+   bun run tauri:build:debug
+   ```
 
 ### Environment Variables
 


### PR DESCRIPTION
I added documentation for the `TAURI_SIGNING_PRIVATE_KEY` to make it easier for new devs to start, and save time waiting for builds that will fail due to this not being set.  This fixes #12.