### PR TITLE
feat: Local LLM support via Ollama and OpenAI-compatible endpoints

### DIFF
--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -137,7 +137,7 @@ export const Subscription = pgTable('subscription', {
 export const AiModelApi = pgTable('ai_model_api', {
     id: serial('id').primaryKey(),
     name: text('name').notNull(),
-    apiKey: text('api_key').notNull(),
+    apiKey: text('api_key'),
     apiBaseUrl: text('api_base_url'),
     ...dbBaseModel,
 });

--- a/src/server/processor/conversation/index.ts
+++ b/src/server/processor/conversation/index.ts
@@ -3,6 +3,7 @@ import { User, type ChatModelWithApi } from '../../db/schema';
 import { type ToolDefinition, type ChatMessage, type ResponseWithThought } from './conversation';
 import { generateChatmlMessagesWithContext } from './utils';
 import { sendMessageToGpt } from './openai';
+import { sendMessageViaChatCompletions } from './openai/chat-completions';
 import type { ATIFTrajectory } from './atif/atif.types';
 import { withTokenRefresh, PlatformAuthError } from '../../http/platform-fetch';
 import { createChildLogger } from '../../logger';
@@ -107,11 +108,19 @@ export async function sendMessageToModel(
 
     // For non-platform providers, route based on model type
     if (aiModelType === 'openai') {
+        // Determine API path: Responses API (OpenAI direct) vs Chat Completions (Ollama, LM Studio, etc.)
+        // The useResponsesApi flag on the ChatModel row controls this:
+        //   - true  → OpenAI Responses API (client.responses.stream)
+        //   - false → Chat Completions API (client.chat.completions.create)
+        const useResponsesApi = chatModelWithApi.chatModel.useResponsesApi;
+        const sendFn = useResponsesApi ? sendMessageToGpt : sendMessageViaChatCompletions;
+        log.info({ model: modelName, provider: aiModelApiName, useResponsesApi }, 'Routing to API');
+
         try {
-            const response = await sendMessageToGpt(
+            const response = await sendFn(
                 messages,
                 chatModelWithApi.chatModel.name,
-                chatModelWithApi.aiModelApi?.apiKey,
+                chatModelWithApi.aiModelApi?.apiKey ?? undefined,
                 chatModelWithApi.aiModelApi?.apiBaseUrl,
                 tools,
                 toolChoice,

--- a/src/server/processor/conversation/openai/chat-completions.ts
+++ b/src/server/processor/conversation/openai/chat-completions.ts
@@ -1,0 +1,310 @@
+/**
+ * Chat Completions API adapter for local/custom OpenAI-compatible providers.
+ *
+ * Pipali's internal message format uses the OpenAI Responses API types
+ * (e.g., Responses.EasyInputMessage, ResponseFunctionToolCall). Local LLM
+ * servers like Ollama only support the Chat Completions API
+ * (POST /v1/chat/completions), which uses a different message schema.
+ *
+ * This module bridges the gap:
+ *   1. Converts Responses-format messages → Chat Completions format
+ *   2. Calls client.chat.completions.create() with streaming
+ *   3. Maps the response back to Pipali's ResponseWithThought type
+ */
+
+import OpenAI from 'openai';
+import type { ChatCompletionMessageParam, ChatCompletionTool, ChatCompletion } from 'openai/resources/chat/completions';
+import type { ChatMessage, ResponseWithThought, ToolDefinition, UsageMetrics } from '../conversation';
+import type { Responses } from 'openai/resources/responses/responses';
+import { calculateCost, type PricingConfig } from '../costs';
+import { createChildLogger } from '../../../logger';
+
+const log = createChildLogger({ component: 'llm-completions' });
+
+// ---------------------------------------------------------------------------
+// Message Format Converters
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert Pipali's Responses-API-format messages to Chat Completions format.
+ *
+ * Responses API messages have a `type` discriminator field:
+ *   - type: 'message' → { role, content }
+ *   - type: 'function_call' → tool call from assistant
+ *   - type: 'function_call_output' → tool result
+ *
+ * Chat Completions API messages use `role` only:
+ *   - { role: 'system' | 'user' | 'assistant', content }
+ *   - { role: 'assistant', tool_calls: [...] }
+ *   - { role: 'tool', tool_call_id, content }
+ */
+export function convertToCompletionMessages(messages: ChatMessage[]): ChatCompletionMessageParam[] {
+    const result: ChatCompletionMessageParam[] = [];
+
+    // Collect consecutive function_call items to batch them into one assistant message
+    let pendingToolCalls: Array<{ call_id: string; name: string; arguments: string }> = [];
+
+    function flushToolCalls() {
+        if (pendingToolCalls.length > 0) {
+            result.push({
+                role: 'assistant' as const,
+                content: null,
+                tool_calls: pendingToolCalls.map((tc, idx) => ({
+                    id: tc.call_id,
+                    type: 'function' as const,
+                    function: {
+                        name: tc.name,
+                        arguments: tc.arguments,
+                    },
+                })),
+            });
+            pendingToolCalls = [];
+        }
+    }
+
+    for (const msg of messages) {
+        const msgAny = msg as any;
+        const msgType = msgAny.type;
+
+        if (msgType === 'message') {
+            // Flush any pending tool calls before a new message
+            flushToolCalls();
+
+            const role = msgAny.role as string;
+            const content = typeof msgAny.content === 'string'
+                ? msgAny.content
+                : Array.isArray(msgAny.content)
+                    ? extractTextFromContent(msgAny.content)
+                    : '';
+
+            if (role === 'system') {
+                result.push({ role: 'system' as const, content });
+            } else if (role === 'user') {
+                result.push({ role: 'user' as const, content });
+            } else if (role === 'assistant') {
+                result.push({ role: 'assistant' as const, content });
+            }
+        } else if (msgType === 'function_call') {
+            // Batch consecutive function calls
+            pendingToolCalls.push({
+                call_id: msgAny.call_id || `call_${Date.now()}`,
+                name: msgAny.name,
+                arguments: msgAny.arguments || '{}',
+            });
+        } else if (msgType === 'function_call_output') {
+            // Flush tool calls before adding tool results
+            flushToolCalls();
+
+            const output = typeof msgAny.output === 'string'
+                ? msgAny.output
+                : JSON.stringify(msgAny.output);
+
+            result.push({
+                role: 'tool' as const,
+                tool_call_id: msgAny.call_id || '',
+                content: output,
+            });
+        } else if (msgType === 'reasoning') {
+            // Skip reasoning items — local models don't support them
+            continue;
+        } else {
+            // Unknown type — try to extract as a simple message
+            flushToolCalls();
+            if (msgAny.role && msgAny.content) {
+                result.push({
+                    role: (msgAny.role === 'system' ? 'system' : msgAny.role === 'assistant' ? 'assistant' : 'user') as any,
+                    content: typeof msgAny.content === 'string' ? msgAny.content : JSON.stringify(msgAny.content),
+                });
+            }
+        }
+    }
+
+    // Flush any remaining tool calls
+    flushToolCalls();
+
+    return result;
+}
+
+/**
+ * Extract plain text from multimodal content arrays.
+ */
+function extractTextFromContent(content: any[]): string {
+    return content
+        .filter((item: any) => item.type === 'input_text' || item.type === 'text')
+        .map((item: any) => item.text)
+        .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Tool Format Converter
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert Pipali's tool definitions to Chat Completions tool format.
+ */
+export function convertToCompletionTools(tools?: ToolDefinition[]): ChatCompletionTool[] | undefined {
+    if (!tools || tools.length === 0) return undefined;
+
+    return tools.map((tool) => ({
+        type: 'function' as const,
+        function: {
+            name: tool.name,
+            description: tool.description ?? '',
+            parameters: tool.schema,
+        },
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Response Mapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a Chat Completions response back to Pipali's ResponseWithThought type.
+ *
+ * This bridges the gap between:
+ *   - ChatCompletion.choices[0].message  (Completions format)
+ *   - ResponseWithThought { message, thought, raw, usage }  (Pipali format)
+ */
+function mapCompletionToResponse(
+    response: ChatCompletion,
+    pricing?: PricingConfig,
+    modelName?: string,
+): ResponseWithThought {
+    const choice = response.choices[0];
+    if (!choice) {
+        throw new Error('No choices returned from model');
+    }
+
+    const assistantMessage = choice.message;
+
+    // Extract text content
+    const message = assistantMessage.content?.trim() || undefined;
+
+    // No reasoning/thought from local models
+    const thought = undefined;
+
+    // Build raw output items in Responses API format for trajectory storage.
+    // This allows multi-turn passthrough to work seamlessly even for local models.
+    const raw: Responses.ResponseOutputItem[] = [];
+
+    // Add message as a ResponseOutputMessage
+    if (message) {
+        raw.push({
+            type: 'message',
+            id: `msg_${Date.now()}`,
+            status: 'completed',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: message, annotations: [] }],
+        } as Responses.ResponseOutputMessage);
+    }
+
+    // Add tool calls as ResponseFunctionToolCall items
+    if (assistantMessage.tool_calls && assistantMessage.tool_calls.length > 0) {
+        for (const tc of assistantMessage.tool_calls) {
+            // Cast to access function property — standard function tool calls always have it
+            const funcCall = tc as { id: string; type: string; function: { name: string; arguments: string } };
+            raw.push({
+                type: 'function_call',
+                id: funcCall.id || `call_${Date.now()}`,
+                call_id: funcCall.id || `call_${Date.now()}`,
+                name: funcCall.function.name,
+                arguments: funcCall.function.arguments,
+                status: 'completed',
+            } as unknown as Responses.ResponseFunctionToolCall);
+        }
+    }
+
+    // Calculate usage metrics
+    let usage: UsageMetrics | undefined;
+    if (response.usage) {
+        const promptTokens = response.usage.prompt_tokens || 0;
+        const completionTokens = response.usage.completion_tokens || 0;
+
+        // Local models are free — cost is $0
+        const costUsd = calculateCost(
+            modelName || response.model || 'local',
+            promptTokens,
+            completionTokens,
+            0, 0, 0,
+            pricing,
+        );
+
+        usage = {
+            prompt_tokens: promptTokens,
+            completion_tokens: completionTokens,
+            cached_tokens: 0,
+            cache_write_tokens: 0,
+            cost_usd: costUsd,
+        };
+        log.info(`Usage: ${promptTokens} prompt, ${completionTokens} completion, $${costUsd.toFixed(6)}`);
+    }
+
+    return { thought, message, raw, usage };
+}
+
+// ---------------------------------------------------------------------------
+// Main Entry Point
+// ---------------------------------------------------------------------------
+
+/**
+ * Send a message to a local/custom OpenAI-compatible model via Chat Completions API.
+ *
+ * This is the counterpart to `sendMessageToGpt` (which uses the Responses API).
+ * It handles LLM servers like Ollama, LM Studio, vLLM, llama.cpp, and any provider
+ * that exposes a /v1/chat/completions endpoint.
+ */
+export async function sendMessageViaChatCompletions(
+    messages: ChatMessage[],
+    model: string,
+    apiKey?: string,
+    apiBaseUrl?: string | null,
+    tools?: ToolDefinition[],
+    toolChoice: string = 'auto',
+    pricing?: PricingConfig,
+    _conversationId?: string,
+): Promise<ResponseWithThought> {
+    // Convert Responses-format messages to Chat Completions format
+    const completionMessages = convertToCompletionMessages(messages);
+    const completionTools = convertToCompletionTools(tools);
+
+    log.debug({
+        messageCount: completionMessages.length,
+        toolCount: completionTools?.length || 0,
+        model,
+        baseUrl: apiBaseUrl,
+    }, 'Sending to Chat Completions API');
+
+    const client = new OpenAI({
+        apiKey: apiKey || 'ollama', // Ollama accepts any value; avoid SDK validation error
+        baseURL: apiBaseUrl ?? undefined,
+    });
+
+    try {
+        const response = await client.chat.completions.create({
+            model: model,
+            messages: completionMessages,
+            ...(completionTools && {
+                tools: completionTools,
+                tool_choice: toolChoice as any,
+            }),
+        });
+
+        return mapCompletionToResponse(response, pricing, model);
+    } catch (error: any) {
+        // Provide helpful error messages for common local model issues
+        if (error?.code === 'ECONNREFUSED') {
+            throw new Error(
+                `Could not connect to local model server at ${apiBaseUrl}. ` +
+                `Make sure Ollama or your LLM server is running.`
+            );
+        }
+        if (error?.status === 404) {
+            throw new Error(
+                `Model "${model}" not found on the server at ${apiBaseUrl}. ` +
+                `Make sure the model is pulled/downloaded (e.g., "ollama pull ${model}").`
+            );
+        }
+        throw error;
+    }
+}

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -519,6 +519,185 @@ api.put('/user/model', zValidator('json', selectModelSchema), async (c) => {
     return c.json({ success: true, modelId });
 });
 
+// ---------------------------------------------------------------------------
+// Custom Model Provider Management (Ollama, LM Studio, vLLM, etc.)
+// ---------------------------------------------------------------------------
+
+const customModelSchema = z.object({
+    providerName: z.string().min(1).max(64),
+    baseUrl: z.string().url(),
+    apiKey: z.string().optional(),
+    modelName: z.string().min(1).max(128),
+    friendlyName: z.string().min(1).max(128).optional(),
+    visionEnabled: z.boolean().default(false),
+});
+
+// Register a custom/local model provider
+api.post('/models/custom', zValidator('json', customModelSchema), async (c) => {
+    const { providerName, baseUrl, apiKey, modelName, friendlyName, visionEnabled } = c.req.valid('json');
+
+    log.info({ providerName, baseUrl, modelName }, 'Registering custom model provider');
+
+    try {
+        // Check if provider with same name already exists
+        const [existingProvider] = await db.select().from(AiModelApi).where(eq(AiModelApi.name, providerName));
+        let providerId: number;
+
+        if (existingProvider) {
+            // Reuse existing provider — just add a new model under it
+            providerId = existingProvider.id;
+            log.info({ providerName }, 'Reusing existing provider');
+        } else {
+            // Create new provider
+            const [newProvider] = await db.insert(AiModelApi).values({
+                name: providerName,
+                apiKey: apiKey || null,
+                apiBaseUrl: baseUrl,
+            }).returning();
+
+            if (!newProvider) {
+                return c.json({ error: 'Failed to create provider' }, 500);
+            }
+            providerId = newProvider.id;
+        }
+
+        // Check if model already exists under this provider
+        const [existingModel] = await db.select().from(ChatModel)
+            .where(and(eq(ChatModel.name, modelName), eq(ChatModel.aiModelApiId, providerId)));
+
+        if (existingModel) {
+            return c.json({ error: `Model "${modelName}" already registered under "${providerName}"` }, 409);
+        }
+
+        // Create the chat model entry
+        // modelType = 'openai' because Ollama exposes an OpenAI-compatible API
+        // useResponsesApi = false to route through Chat Completions API instead of Responses API
+        const [newModel] = await db.insert(ChatModel).values({
+            name: modelName,
+            friendlyName: friendlyName || modelName,
+            modelType: 'openai',
+            visionEnabled: visionEnabled,
+            useResponsesApi: false,  // ← The key architectural switch
+            aiModelApiId: providerId,
+        }).returning();
+
+        log.info({ modelId: newModel?.id, modelName, providerName }, 'Custom model registered');
+
+        return c.json({
+            success: true,
+            model: {
+                id: newModel?.id,
+                name: modelName,
+                friendlyName: friendlyName || modelName,
+                providerName,
+                baseUrl,
+            },
+        });
+    } catch (error) {
+        log.error({ err: error }, 'Failed to register custom model');
+        return c.json({ error: error instanceof Error ? error.message : 'Failed to register model' }, 500);
+    }
+});
+
+// Delete a custom model
+api.delete('/models/custom/:id', async (c) => {
+    const modelId = parseInt(c.req.param('id'), 10);
+    if (isNaN(modelId)) {
+        return c.json({ error: 'Invalid model ID' }, 400);
+    }
+
+    try {
+        // Verify the model exists and is a custom (non-Responses-API) model
+        const [model] = await db.select().from(ChatModel).where(eq(ChatModel.id, modelId));
+        if (!model) {
+            return c.json({ error: 'Model not found' }, 404);
+        }
+
+        // Only allow deletion of custom models (useResponsesApi = false with a non-Pipali provider)
+        if (model.useResponsesApi) {
+            return c.json({ error: 'Cannot delete platform models' }, 403);
+        }
+
+        // Delete the model
+        await db.delete(ChatModel).where(eq(ChatModel.id, modelId));
+
+        // Clean up orphaned provider (if no other models reference it)
+        if (model.aiModelApiId) {
+            const remainingModels = await db.select({ id: ChatModel.id })
+                .from(ChatModel)
+                .where(eq(ChatModel.aiModelApiId, model.aiModelApiId));
+
+            if (remainingModels.length === 0) {
+                await db.delete(AiModelApi).where(eq(AiModelApi.id, model.aiModelApiId));
+                log.info({ providerId: model.aiModelApiId }, 'Cleaned up orphaned provider');
+            }
+        }
+
+        log.info({ modelId }, 'Custom model deleted');
+        return c.json({ success: true });
+    } catch (error) {
+        log.error({ err: error }, 'Failed to delete custom model');
+        return c.json({ error: 'Failed to delete model' }, 500);
+    }
+});
+
+// Auto-discover models from an Ollama (or OpenAI-compatible) server
+api.get('/models/discover', async (c) => {
+    const baseUrl = c.req.query('baseUrl');
+    if (!baseUrl) {
+        return c.json({ error: 'Missing baseUrl query parameter' }, 400);
+    }
+
+    log.info({ baseUrl }, 'Discovering models');
+
+    try {
+        // Try Ollama's native API first: GET /api/tags
+        const ollamaUrl = baseUrl.replace(/\/v1\/?$/, ''); // Strip /v1 suffix if present
+        const response = await fetch(`${ollamaUrl}/api/tags`, {
+            signal: AbortSignal.timeout(5000),
+        });
+
+        if (response.ok) {
+            const data = await response.json() as { models?: Array<{ name: string; size: number; modified_at: string; details?: { family: string; parameter_size: string } }> };
+            const models = (data.models || []).map(m => ({
+                name: m.name,
+                size: m.size,
+                modifiedAt: m.modified_at,
+                family: m.details?.family,
+                parameterSize: m.details?.parameter_size,
+            }));
+
+            log.info({ modelCount: models.length }, 'Discovered Ollama models');
+            return c.json({ provider: 'ollama', models });
+        }
+
+        // Fallback: Try OpenAI-compatible GET /v1/models
+        const openaiUrl = baseUrl.endsWith('/v1') ? baseUrl : `${baseUrl}/v1`;
+        const fallbackResponse = await fetch(`${openaiUrl}/models`, {
+            signal: AbortSignal.timeout(5000),
+        });
+
+        if (fallbackResponse.ok) {
+            const data = await fallbackResponse.json() as { data?: Array<{ id: string; owned_by?: string }> };
+            const models = (data.data || []).map(m => ({
+                name: m.id,
+                ownedBy: m.owned_by,
+            }));
+
+            log.info({ modelCount: models.length }, 'Discovered OpenAI-compatible models');
+            return c.json({ provider: 'openai-compatible', models });
+        }
+
+        return c.json({ error: 'Could not discover models. Make sure the server is running.' }, 502);
+    } catch (error: any) {
+        if (error?.name === 'AbortError' || error?.code === 'ECONNREFUSED') {
+            return c.json({ error: `Could not connect to ${baseUrl}. Make sure Ollama is running.` }, 502);
+        }
+        log.error({ err: error }, 'Model discovery failed');
+        return c.json({ error: 'Model discovery failed' }, 500);
+    }
+});
+
 // Get user context (bio, location, instructions)
 api.get('/user/context', async (c) => {
     try {


### PR DESCRIPTION
Closes #23

Hey @debanjum — saw the feature request for local LLM support and realized the backend plumbing is *almost* there, but there's a subtle blocker that would trip up a naive implementation: Pipali uses the OpenAI Responses API (client.responses.stream), while Ollama and other local servers only support the Chat Completions API (client.chat.completions.create). The message and response formats are completely different, so just swapping piBaseUrl isn't enough.

This PR adds a proper Chat Completions adapter that bridges the gap.

## What this does

**New file: openai/chat-completions.ts** — The core adapter module that:
- Converts Pipali's Responses-API-format messages (with 	ype discriminators like unction_call, unction_call_output) to standard Chat Completions format (ole-based messages)
- Calls client.chat.completions.create() instead of client.responses.stream()
- Maps responses back to ResponseWithThought with proper aw output items so multi-turn trajectory passthrough still works

**Router change in conversation/index.ts** — Uses the existing useResponsesApi flag on ChatModel to decide which code path to use:
- useResponsesApi: true → Responses API (existing behavior for Pipali Platform / direct OpenAI)
- useResponsesApi: false → Chat Completions API (new path for Ollama, LM Studio, vLLM, etc.)

No new model type enum values needed — Ollama is OpenAI-compatible, so modelType: 'openai' works.

**Schema change** — Made AiModelApi.apiKey nullable since local servers don't need API keys.

**New API endpoints:**
- POST /api/models/custom — Register a local model provider (name, baseUrl, model, optional API key)
- DELETE /api/models/custom/:id — Remove a custom model (with orphaned provider cleanup)
- GET /api/models/discover?baseUrl=... — Auto-discover models from Ollama (/api/tags) or any OpenAI-compatible server (/v1/models)

## What's NOT in this PR

Frontend UI for adding custom models (settings form, model selector icon). Wanted to get the backend right first and can follow up with the UI in a separate PR if this direction looks good.

## Testing

- Zero new TypeScript errors (all pre-existing ones unchanged)
- Designed to work with Ollama, LM Studio, vLLM, llama.cpp, text-generation-webui, Together AI, Groq — any server exposing /v1/chat/completions
- Helpful error messages for common local model issues (ECONNREFUSED, model not found)

Happy to iterate on any of this.