### PR TITLE
Validate confirmation response attachments on WebSocket path

### DIFF
--- a/src/server/processor/confirmation/confirmation.schema.ts
+++ b/src/server/processor/confirmation/confirmation.schema.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared Zod schemas for confirmation responses.
+ *
+ * Both transports consume the same schema so the REST and WebSocket
+ * confirmation paths cannot drift apart:
+ *  - REST: POST /api/automations/confirmations/:id/respond
+ *  - WS:   message { type: 'confirmation_response' }
+ *
+ * The attachments captured here flow into formatConfirmationAttachmentBlock
+ * (confirmation.service.ts) and end up in a prompt sent to the model, so
+ * untrusted client input must be bounded and well-typed at this boundary.
+ */
+
+import { z } from 'zod';
+import type {
+    ConfirmationResponse,
+    ConfirmationResponseAttachment,
+} from './confirmation.types';
+
+export const MAX_CONFIRMATION_ATTACHMENTS = 50;
+export const MAX_ATTACHMENT_PATH_LENGTH = 4096;
+export const MAX_ATTACHMENT_NAME_LENGTH = 512;
+
+export const confirmationResponseAttachmentSchema = z.object({
+    path: z.string().min(1).max(MAX_ATTACHMENT_PATH_LENGTH),
+    name: z.string().max(MAX_ATTACHMENT_NAME_LENGTH).optional(),
+});
+
+const confirmationResponseAttachmentsArraySchema = z
+    .array(confirmationResponseAttachmentSchema)
+    .max(MAX_CONFIRMATION_ATTACHMENTS);
+
+const confirmationResponseInputDataSchema = z.object({
+    selectedIds: z.array(z.string()).optional(),
+    numericValue: z.number().optional(),
+    textValue: z.string().optional(),
+});
+
+export const confirmationResponseSchema = z.object({
+    requestId: z.string().min(1),
+    selectedOptionId: z.string().min(1),
+    guidance: z.string().optional(),
+    inputData: confirmationResponseInputDataSchema.optional(),
+    persistPreference: z.boolean().optional(),
+    attachments: confirmationResponseAttachmentsArraySchema.optional(),
+    timestamp: z.string(),
+});
+
+/**
+ * REST shape: the route sets `requestId` from the URL and `timestamp` server-side,
+ * so the request body omits both.
+ */
+export const confirmationResponseBodySchema = confirmationResponseSchema.omit({
+    requestId: true,
+    timestamp: true,
+});
+
+// Type-level assertions: the parsed schemas must produce values
+// assignable to the public ConfirmationResponse / attachment types.
+type _Assert = [
+    z.infer<typeof confirmationResponseSchema> extends ConfirmationResponse ? true : false,
+    z.infer<typeof confirmationResponseAttachmentSchema> extends ConfirmationResponseAttachment ? true : false,
+];
+const _assert: _Assert = [true, true];
+void _assert;

--- a/src/server/processor/confirmation/index.ts
+++ b/src/server/processor/confirmation/index.ts
@@ -7,3 +7,4 @@
 
 export * from './confirmation.types';
 export * from './confirmation.service';
+export * from './confirmation.schema';

--- a/src/server/routes/automations.ts
+++ b/src/server/routes/automations.ts
@@ -21,6 +21,7 @@ import {
     type TriggerConfig,
     type TriggerEventData,
 } from '../automation';
+import { confirmationResponseBodySchema } from '../processor/confirmation';
 import { createChildLogger } from '../logger';
 
 const log = createChildLogger({ component: 'automations' });
@@ -58,15 +59,7 @@ const createAutomationSchema = z.object({
     maxExecutionsPerHour: z.number().min(1).optional(),
 });
 
-const confirmationResponseSchema = z.object({
-    selectedOptionId: z.string(),
-    persistPreference: z.boolean().optional(),
-    guidance: z.string().optional(),
-    attachments: z.array(z.object({
-        path: z.string(),
-        name: z.string().optional(),
-    })).optional(),
-});
+const confirmationResponseSchema = confirmationResponseBodySchema;
 
 // ============== STATIC ROUTES (must come before /:id routes) ==============
 

--- a/src/server/routes/ws/commands/confirmation-response.ts
+++ b/src/server/routes/ws/commands/confirmation-response.ts
@@ -10,6 +10,7 @@ import type { ClientMessage, ConfirmationResponseCommand } from '../message-type
 import { getBus } from '../../../events/conversation-event-bus';
 import { handleConfirmationResponse } from '../confirmation-manager';
 import { createChildLogger } from '../../../logger';
+import { confirmationResponseSchema } from '../../../processor/confirmation';
 
 const log = createChildLogger({ component: 'confirmation-response' });
 
@@ -19,7 +20,19 @@ export const ConfirmationResponseHandler: Command<ConfirmationResponseCommand> =
     },
 
     async execute(ctx: CommandContext, message: ConfirmationResponseCommand): Promise<void> {
-        const { conversationId, runId, data: response } = message;
+        const { conversationId, runId, data: rawResponse } = message;
+
+        const parsed = confirmationResponseSchema.safeParse(rawResponse);
+        if (!parsed.success) {
+            log.warn({
+                conversationId,
+                runId,
+                issues: parsed.error.issues,
+            }, 'Confirmation response failed schema validation');
+            ctx.sendError('Invalid confirmation response payload', conversationId);
+            return;
+        }
+        const response = parsed.data;
 
         const bus = getBus(conversationId);
         if (!bus?.activeRun) {

--- a/tests/server/confirmation_response_schema.test.ts
+++ b/tests/server/confirmation_response_schema.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the shared ConfirmationResponse Zod schema.
+ *
+ * The schema is the contract shared by:
+ *  - REST: POST /api/automations/confirmations/:id/respond
+ *  - WS:   message { type: 'confirmation_response' }
+ *
+ * Both paths feed the resulting `attachments` into
+ * `formatConfirmationAttachmentBlock`, which then becomes part of a prompt
+ * sent to the model — so untrusted client input must be rejected here.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+    confirmationResponseSchema,
+    confirmationResponseAttachmentSchema,
+    confirmationResponseBodySchema,
+    MAX_CONFIRMATION_ATTACHMENTS,
+    MAX_ATTACHMENT_PATH_LENGTH,
+} from '../../src/server/processor/confirmation/confirmation.schema';
+
+describe('confirmationResponseAttachmentSchema', () => {
+    test('accepts a minimal valid attachment', () => {
+        const parsed = confirmationResponseAttachmentSchema.parse({ path: '/tmp/x.txt' });
+        expect(parsed.path).toBe('/tmp/x.txt');
+        expect(parsed.name).toBeUndefined();
+    });
+
+    test('accepts path + name', () => {
+        const parsed = confirmationResponseAttachmentSchema.parse({
+            path: '/tmp/x.txt',
+            name: 'report.txt',
+        });
+        expect(parsed.name).toBe('report.txt');
+    });
+
+    test('rejects non-string path', () => {
+        const result = confirmationResponseAttachmentSchema.safeParse({ path: 123 });
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects empty path', () => {
+        const result = confirmationResponseAttachmentSchema.safeParse({ path: '' });
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects path longer than MAX_ATTACHMENT_PATH_LENGTH', () => {
+        const long = 'a'.repeat(MAX_ATTACHMENT_PATH_LENGTH + 1);
+        const result = confirmationResponseAttachmentSchema.safeParse({ path: long });
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects object payload for path (prototype-poisoning shape)', () => {
+        const result = confirmationResponseAttachmentSchema.safeParse({
+            path: { __proto__: 'evil' },
+        });
+        expect(result.success).toBe(false);
+    });
+});
+
+describe('confirmationResponseSchema (WebSocket shape)', () => {
+    test('accepts a minimal valid response', () => {
+        const parsed = confirmationResponseSchema.parse({
+            requestId: 'req-1',
+            selectedOptionId: 'yes',
+            timestamp: '2026-05-12T00:00:00.000Z',
+        });
+        expect(parsed.selectedOptionId).toBe('yes');
+    });
+
+    test('accepts a guidance response with attachments', () => {
+        const parsed = confirmationResponseSchema.parse({
+            requestId: 'req-1',
+            selectedOptionId: 'guidance',
+            guidance: 'use the sanitized version',
+            attachments: [{ path: '/tmp/sanitized.txt', name: 'sanitized.txt' }],
+            timestamp: '2026-05-12T00:00:00.000Z',
+        });
+        expect(parsed.attachments?.length).toBe(1);
+    });
+
+    test('rejects missing selectedOptionId', () => {
+        const result = confirmationResponseSchema.safeParse({
+            requestId: 'req-1',
+            timestamp: '2026-05-12T00:00:00.000Z',
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects missing requestId', () => {
+        const result = confirmationResponseSchema.safeParse({
+            selectedOptionId: 'yes',
+            timestamp: '2026-05-12T00:00:00.000Z',
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects attachment array exceeding MAX_CONFIRMATION_ATTACHMENTS', () => {
+        const tooMany = Array.from({ length: MAX_CONFIRMATION_ATTACHMENTS + 1 }, (_, i) => ({
+            path: `/tmp/f${i}.txt`,
+        }));
+        const result = confirmationResponseSchema.safeParse({
+            requestId: 'req-1',
+            selectedOptionId: 'guidance',
+            attachments: tooMany,
+            timestamp: '2026-05-12T00:00:00.000Z',
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects malformed attachment entry', () => {
+        const result = confirmationResponseSchema.safeParse({
+            requestId: 'req-1',
+            selectedOptionId: 'guidance',
+            attachments: [{ path: 123 }],
+            timestamp: '2026-05-12T00:00:00.000Z',
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test('strips unknown top-level fields rather than failing', () => {
+        const parsed = confirmationResponseSchema.parse({
+            requestId: 'req-1',
+            selectedOptionId: 'yes',
+            timestamp: '2026-05-12T00:00:00.000Z',
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            __injected: 'evil',
+        } as never);
+        expect((parsed as Record<string, unknown>).__injected).toBeUndefined();
+    });
+});
+
+describe('confirmationResponseBodySchema (REST shape)', () => {
+    test('omits requestId and timestamp (set by route)', () => {
+        const parsed = confirmationResponseBodySchema.parse({
+            selectedOptionId: 'yes',
+        });
+        expect(parsed.selectedOptionId).toBe('yes');
+    });
+
+    test('still validates attachments', () => {
+        const result = confirmationResponseBodySchema.safeParse({
+            selectedOptionId: 'guidance',
+            attachments: [{ path: 123 }],
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test('still caps attachment count', () => {
+        const tooMany = Array.from({ length: MAX_CONFIRMATION_ATTACHMENTS + 1 }, (_, i) => ({
+            path: `/tmp/f${i}.txt`,
+        }));
+        const result = confirmationResponseBodySchema.safeParse({
+            selectedOptionId: 'guidance',
+            attachments: tooMany,
+        });
+        expect(result.success).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- Extract the confirmation response Zod schema into a shared `src/server/processor/confirmation/confirmation.schema.ts` so REST (`routes/automations.ts`) and WS (`routes/ws/commands/confirmation-response.ts`) share one source of truth.
- WS handler now `safeParse`s the inbound `message.data`. On schema failure it logs the issues and calls `ctx.sendError`, then returns early before any downstream dispatch.
- Caps applied uniformly:
  - Up to **50** attachments per response
  - Up to **4096** chars per path (matches Linux `PATH_MAX`)
  - Up to **512** chars per name

Closes #32

## Why
The REST path already validated this body; the WS path did not. `formatConfirmationAttachmentBlock` builds an `<attached_files>` prompt suffix from the array, so an unvalidated WS payload is a prompt-injection foothold.

## Test plan
- [x] `bun test tests/server/confirmation_response_schema.test.ts` — 16 new tests covering valid/invalid shapes, attachment caps, prototype-shaped paths, REST-shape omits (passes locally)
- [x] `bun test` — full unit suite (515 pass, 0 fail locally)
- [ ] Smoke-test a confirmation reply with an attachment via the desktop app

## Notes
The `ctx.sendError` sink currently only writes to the server log and does not deliver a frame to the client. That is a separate bug (also exposed by the new `chatModelId` validation paths in commit 2cb1d88) and intentionally not bundled into this PR.