### PR TITLE
Guard InputArea submit against fall-through while confirmation is pending

### DIFF
--- a/src/client/components/layout/InputArea.tsx
+++ b/src/client/components/layout/InputArea.tsx
@@ -9,6 +9,7 @@ import { formatFileSize } from '../../utils/formatting';
 import { localImageSrc } from '../../utils/markdown';
 import { getApiBaseUrl } from '../../utils/api';
 import { isTauri } from '../../utils/tauri';
+import { resolveInputSubmitAction } from '../../utils/input-submit';
 import { useTranslation } from 'react-i18next';
 
 interface InputAreaProps {
@@ -129,12 +130,19 @@ export function InputArea({
 
             <div className="input-container">
                 <form onSubmit={(e) => {
-                    // When confirmation is pending, send as guidance instead of new message
-                    // This handles mobile where users tap the send button instead of pressing Enter
-                    if (pendingConfirmation && (input.trim() || hasFiles)) {
+                    const action = resolveInputSubmitAction({
+                        pendingConfirmation: !!pendingConfirmation,
+                        inputTrimmed: input.trim(),
+                        hasFiles,
+                    });
+                    if (action.kind === 'guidance') {
                         e.preventDefault();
-                        onConfirmationRespond('guidance', input.trim() || undefined);
+                        onConfirmationRespond('guidance', action.text);
                         onInputChange('');
+                        return;
+                    }
+                    if (action.kind === 'consume') {
+                        e.preventDefault();
                         return;
                     }
                     onSubmit(e);
@@ -182,12 +190,25 @@ export function InputArea({
                             }
                         }}
                         onKeyDown={(e) => {
-                            // When confirmation is pending, Enter sends guidance
-                            if (pendingConfirmation && e.key === 'Enter' && !e.shiftKey && (input.trim() || hasFiles)) {
-                                e.preventDefault();
-                                onConfirmationRespond('guidance', input.trim() || undefined);
-                                onInputChange('');
-                                return;
+                            // When confirmation is pending, Enter resolves it
+                            // (guidance + text/files, or a no-op while we wait
+                            // for the user to type or click an option button).
+                            if (pendingConfirmation && e.key === 'Enter' && !e.shiftKey) {
+                                const action = resolveInputSubmitAction({
+                                    pendingConfirmation: true,
+                                    inputTrimmed: input.trim(),
+                                    hasFiles,
+                                });
+                                if (action.kind === 'guidance') {
+                                    e.preventDefault();
+                                    onConfirmationRespond('guidance', action.text);
+                                    onInputChange('');
+                                    return;
+                                }
+                                if (action.kind === 'consume') {
+                                    e.preventDefault();
+                                    return;
+                                }
                             }
                             // Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux): background task
                             if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !e.shiftKey) {

--- a/src/client/utils/input-submit.ts
+++ b/src/client/utils/input-submit.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure helper that decides what the chat input area should do on submit.
+ *
+ * Both the form's onSubmit and the textarea's Enter handler need to agree on
+ * the same three outcomes, so this lives in one place:
+ *
+ *  - `guidance` — there's a pending confirmation and the user has something to
+ *    send. The InputArea calls onConfirmationRespond('guidance', text).
+ *  - `consume`  — there's a pending confirmation but nothing to send.
+ *    The InputArea must preventDefault and stop, never falling through to the
+ *    parent's "send a new message" handler.
+ *  - `default`  — no confirmation pending, or empty submit while idle.
+ *    The InputArea defers to the parent (which has its own canSend guards).
+ */
+
+export type InputSubmitAction =
+    | { kind: 'guidance'; text?: string }
+    | { kind: 'consume' }
+    | { kind: 'default' };
+
+export interface InputSubmitParams {
+    pendingConfirmation: boolean;
+    inputTrimmed: string;
+    hasFiles: boolean;
+}
+
+export function resolveInputSubmitAction(params: InputSubmitParams): InputSubmitAction {
+    const canSend = params.inputTrimmed.length > 0 || params.hasFiles;
+    if (params.pendingConfirmation) {
+        if (canSend) {
+            return { kind: 'guidance', text: params.inputTrimmed || undefined };
+        }
+        return { kind: 'consume' };
+    }
+    return { kind: 'default' };
+}

--- a/tests/client/input-submit.test.ts
+++ b/tests/client/input-submit.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for resolveInputSubmitAction.
+ *
+ * The input area has two trigger paths (form submit and Enter key) that both
+ * decide between three actions: send guidance, defer to parent, or consume.
+ * Centralising the decision into a pure function keeps the two paths in sync
+ * and lets us test the "pending confirmation + empty input" gap directly.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { resolveInputSubmitAction } from '../../src/client/utils/input-submit';
+
+describe('resolveInputSubmitAction', () => {
+    test('defers to parent when no confirmation is pending and input has text', () => {
+        const action = resolveInputSubmitAction({
+            pendingConfirmation: false,
+            inputTrimmed: 'hello',
+            hasFiles: false,
+        });
+        expect(action).toEqual({ kind: 'default' });
+    });
+
+    test('defers to parent when no confirmation is pending and only files are staged', () => {
+        const action = resolveInputSubmitAction({
+            pendingConfirmation: false,
+            inputTrimmed: '',
+            hasFiles: true,
+        });
+        expect(action).toEqual({ kind: 'default' });
+    });
+
+    test('defers to parent on empty submit when no confirmation is pending', () => {
+        // The parent's own handler (or the disabled button) takes care of this.
+        const action = resolveInputSubmitAction({
+            pendingConfirmation: false,
+            inputTrimmed: '',
+            hasFiles: false,
+        });
+        expect(action).toEqual({ kind: 'default' });
+    });
+
+    test('sends guidance with text when confirmation is pending and input has text', () => {
+        const action = resolveInputSubmitAction({
+            pendingConfirmation: true,
+            inputTrimmed: 'use the sanitized version',
+            hasFiles: false,
+        });
+        expect(action).toEqual({ kind: 'guidance', text: 'use the sanitized version' });
+    });
+
+    test('sends guidance with no text when confirmation is pending and only files are staged', () => {
+        const action = resolveInputSubmitAction({
+            pendingConfirmation: true,
+            inputTrimmed: '',
+            hasFiles: true,
+        });
+        expect(action).toEqual({ kind: 'guidance', text: undefined });
+    });
+
+    test('consumes the event when confirmation is pending and both input and files are empty', () => {
+        // The bug fix: previously this case fell through to the parent's
+        // "send a new message" handler while a confirmation was still pending.
+        const action = resolveInputSubmitAction({
+            pendingConfirmation: true,
+            inputTrimmed: '',
+            hasFiles: false,
+        });
+        expect(action).toEqual({ kind: 'consume' });
+    });
+});


### PR DESCRIPTION
## Summary
- Both the form's `onSubmit` and the textarea's Enter handler in `src/client/components/layout/InputArea.tsx` guarded the "send as guidance" path with `(input.trim() || hasFiles)`. An empty submit while a confirmation was pending fell through to the parent's "send a new message" handler.
- Extract the decision into `resolveInputSubmitAction` (new pure helper at `src/client/utils/input-submit.ts`) with three explicit outcomes: `guidance`, `consume`, `default`. The `consume` branch preventDefaults the event.
- Both call sites in `InputArea.tsx` now share the helper so they cannot drift.

Closes #36

## Why this matters
The contract is "while a confirmation dialog is up, Enter resolves it and never sends a new chat message." The send button's `disabled={!canSend}` mostly hides this on desktop, but Enter in the textarea and form submits via other input methods (mobile soft-keyboard Done key, autofill, programmatic) bypass that guard and trigger the parent's normal send path while the confirmation is still on screen.

## Test plan
- [x] `bun test tests/client/input-submit.test.ts` — 6 new tests covering all combinations of pendingConfirmation × inputTrimmed × hasFiles
- [x] `bun test` — full unit suite (no regressions introduced by this PR; one pre-existing `read_file.test.ts` Excel flake that passes in isolation, unrelated to this change)
- [ ] Smoke-test: trigger a confirmation, focus the textarea with empty input, press Enter — confirm the dialog stays put and no new message is sent

## Notes
The fix is intentionally minimal: extract one helper, fix both call sites symmetrically. No change to confirmation-handling logic or to the parent's message-send path.