### PR TITLE
Reject attachments on approved confirmation responses

### DIFF
--- a/src/server/automation/executor/index.ts
+++ b/src/server/automation/executor/index.ts
@@ -13,7 +13,7 @@ import type { TriggerEventData } from '../types';
 import type { ConfirmationContext } from '../../processor/confirmation';
 import { createEmptyPreferences } from '../../processor/confirmation';
 import type { ConfirmationRequest, ConfirmationResponse } from '../../processor/confirmation/confirmation.types';
-import { createStandardConfirmationOptions } from '../../processor/confirmation/confirmation.types';
+import { createStandardConfirmationOptions, isApprovalOptionId } from '../../processor/confirmation/confirmation.types';
 import { getOrCreateBus } from '../../events/conversation-event-bus';
 import { executeRun } from '../../events/run-executor';
 import { createChildLogger } from '../../logger';
@@ -505,7 +505,7 @@ export async function respondToConfirmation(
     }
 
     // Determine status based on response
-    const isApproved = response.selectedOptionId === 'yes' || response.selectedOptionId === 'yes_dont_ask';
+    const isApproved = isApprovalOptionId(response.selectedOptionId);
     const hasGuidance = response.selectedOptionId === 'guidance';
     const confirmationStatus = isApproved || hasGuidance ? 'approved' : 'denied';
 

--- a/src/server/processor/confirmation/confirmation.service.ts
+++ b/src/server/processor/confirmation/confirmation.service.ts
@@ -15,6 +15,7 @@ import {
     type ConfirmationResponseAttachment,
     CONFIRMATION_OPTIONS,
     createStandardConfirmationOptions,
+    isApprovalOptionId,
 } from './confirmation.types';
 
 /**
@@ -172,8 +173,7 @@ export function formatConfirmationAttachmentBlock(attachments?: ConfirmationResp
 export function processConfirmationResponse(
     response: ConfirmationResponse
 ): ConfirmationResult {
-    const approved = response.selectedOptionId === CONFIRMATION_OPTIONS.YES ||
-        response.selectedOptionId === CONFIRMATION_OPTIONS.YES_DONT_ASK;
+    const approved = isApprovalOptionId(response.selectedOptionId);
 
     const skipFutureConfirmations = response.selectedOptionId === CONFIRMATION_OPTIONS.YES_DONT_ASK;
 

--- a/src/server/processor/confirmation/confirmation.types.ts
+++ b/src/server/processor/confirmation/confirmation.types.ts
@@ -117,7 +117,13 @@ export interface ConfirmationResponse {
     };
     /** Whether user chose to persist this preference */
     persistPreference?: boolean;
-    /** File attachments included with the user's response */
+    /**
+     * File attachments included with the user's response.
+     * Only valid on denial paths (NO / GUIDANCE) and on operation-specific
+     * options like ask_user's choices. Approval options (YES / YES_DONT_ASK)
+     * must not carry attachments — `validateConfirmationResponseSemantics`
+     * enforces this at the transport boundary.
+     */
     attachments?: ConfirmationResponseAttachment[];
     /** Timestamp of response */
     timestamp: string;
@@ -139,6 +145,34 @@ export const CONFIRMATION_OPTIONS = {
     NO: 'no',
     GUIDANCE: 'guidance',  // User provided alternative instructions (implicitly declines)
 } as const;
+
+/**
+ * True iff the option ID represents an approval of the operation.
+ * Used to enforce that attachments are not paired with approvals — the
+ * downstream prompt builder only surfaces attachments on the denial side.
+ */
+export function isApprovalOptionId(optionId: string): boolean {
+    return optionId === CONFIRMATION_OPTIONS.YES
+        || optionId === CONFIRMATION_OPTIONS.YES_DONT_ASK;
+}
+
+/**
+ * Validate semantic constraints on a confirmation response that the Zod
+ * shape schema cannot express (cross-field rules). Today this only enforces
+ * the attachments-on-approval rule.
+ */
+export function validateConfirmationResponseSemantics(
+    response: Pick<ConfirmationResponse, 'selectedOptionId' | 'attachments'>,
+): { valid: true } | { valid: false; reason: string } {
+    const attachments = response.attachments ?? [];
+    if (isApprovalOptionId(response.selectedOptionId) && attachments.length > 0) {
+        return {
+            valid: false,
+            reason: 'Attachments are not allowed on approval responses; attach files only with denial/guidance.',
+        };
+    }
+    return { valid: true };
+}
 
 /**
  * Create standard 3-option confirmation (Yes, Yes and don't ask again, No)

--- a/src/server/routes/automations.ts
+++ b/src/server/routes/automations.ts
@@ -21,6 +21,7 @@ import {
     type TriggerConfig,
     type TriggerEventData,
 } from '../automation';
+import { validateConfirmationResponseSemantics } from '../processor/confirmation';
 import { createChildLogger } from '../logger';
 
 const log = createChildLogger({ component: 'automations' });
@@ -113,6 +114,11 @@ automations.post('/confirmations/:id/respond', zValidator('json', confirmationRe
     }
 
     const data = c.req.valid('json');
+
+    const semantic = validateConfirmationResponseSemantics(data);
+    if (!semantic.valid) {
+        return c.json({ error: semantic.reason }, 400);
+    }
 
     const success = await respondToConfirmation(id, {
         requestId: id,

--- a/src/server/routes/ws/commands/confirmation-response.ts
+++ b/src/server/routes/ws/commands/confirmation-response.ts
@@ -9,6 +9,7 @@ import type { Command, CommandContext } from './index';
 import type { ClientMessage, ConfirmationResponseCommand } from '../message-types';
 import { getBus } from '../../../events/conversation-event-bus';
 import { handleConfirmationResponse } from '../confirmation-manager';
+import { validateConfirmationResponseSemantics } from '../../../processor/confirmation';
 import { createChildLogger } from '../../../logger';
 
 const log = createChildLogger({ component: 'confirmation-response' });
@@ -20,6 +21,19 @@ export const ConfirmationResponseHandler: Command<ConfirmationResponseCommand> =
 
     async execute(ctx: CommandContext, message: ConfirmationResponseCommand): Promise<void> {
         const { conversationId, runId, data: response } = message;
+
+        const semantic = validateConfirmationResponseSemantics(response);
+        if (!semantic.valid) {
+            log.warn({
+                conversationId,
+                runId,
+                selectedOptionId: response.selectedOptionId,
+                attachmentCount: response.attachments?.length ?? 0,
+                reason: semantic.reason,
+            }, 'Rejecting confirmation response with invalid semantics');
+            ctx.sendError(semantic.reason, conversationId);
+            return;
+        }
 
         const bus = getBus(conversationId);
         if (!bus?.activeRun) {

--- a/tests/server/automations_confirmation_route.test.ts
+++ b/tests/server/automations_confirmation_route.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Wiring-level test for the REST confirmation respond endpoint.
+ *
+ * Ensures the route's pre-handler returns 400 when YES (or YES_DONT_ASK) is
+ * combined with attachments, before any downstream `respondToConfirmation`
+ * call (which would touch the DB) is reached. A future refactor that moves
+ * the guard past respondToConfirmation will fail this test instead of
+ * silently dropping attachments.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import automations from '../../src/server/routes/automations';
+
+const VALID_UUID = '00000000-0000-4000-8000-000000000001';
+
+async function postRespond(body: Record<string, unknown>): Promise<{ status: number; json: Record<string, unknown> }> {
+    const res = await automations.request(`/confirmations/${VALID_UUID}/respond`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+    return { status: res.status, json };
+}
+
+describe('POST /api/automations/confirmations/:id/respond', () => {
+    test('rejects YES + attachments with 400', async () => {
+        const { status, json } = await postRespond({
+            selectedOptionId: 'yes',
+            attachments: [{ path: '/tmp/x.txt' }],
+        });
+        expect(status).toBe(400);
+        expect(json.error).toMatch(/attach/i);
+    });
+
+    test('rejects YES_DONT_ASK + attachments with 400', async () => {
+        const { status, json } = await postRespond({
+            selectedOptionId: 'yes_dont_ask',
+            attachments: [{ path: '/tmp/x.txt' }],
+        });
+        expect(status).toBe(400);
+        expect(json.error).toMatch(/attach/i);
+    });
+
+    test('rejects an invalid UUID with 400 before the semantic check', async () => {
+        const res = await automations.request('/confirmations/not-a-uuid/respond', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ selectedOptionId: 'yes' }),
+        });
+        expect(res.status).toBe(400);
+    });
+});

--- a/tests/server/confirmation_semantics.test.ts
+++ b/tests/server/confirmation_semantics.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for validateConfirmationResponseSemantics.
+ *
+ * `processConfirmationResponse` only appends the attachment block to the
+ * denialReason when !approved. If the user picks YES (or YES_DONT_ASK) with
+ * attachments, the attachments are silently discarded. This validator
+ * rejects that asymmetric case at the transport boundary so the contract is
+ * explicit and the same on REST and WS.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+    validateConfirmationResponseSemantics,
+    CONFIRMATION_OPTIONS,
+} from '../../src/server/processor/confirmation/confirmation.types';
+
+describe('validateConfirmationResponseSemantics', () => {
+    test('accepts guidance with attachments', () => {
+        const result = validateConfirmationResponseSemantics({
+            selectedOptionId: CONFIRMATION_OPTIONS.GUIDANCE,
+            attachments: [{ path: '/tmp/sanitized.txt' }],
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test('accepts denial with attachments', () => {
+        // The else branch of processConfirmationResponse appends attachments
+        // even for the NO case ("User denied the operation<block>"), so this
+        // remains a valid combination.
+        const result = validateConfirmationResponseSemantics({
+            selectedOptionId: CONFIRMATION_OPTIONS.NO,
+            attachments: [{ path: '/tmp/x.txt' }],
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test('accepts approval with no attachments', () => {
+        const result = validateConfirmationResponseSemantics({
+            selectedOptionId: CONFIRMATION_OPTIONS.YES,
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test('accepts approval with an empty attachments array', () => {
+        const result = validateConfirmationResponseSemantics({
+            selectedOptionId: CONFIRMATION_OPTIONS.YES,
+            attachments: [],
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test('accepts approval with attachments explicitly undefined', () => {
+        const result = validateConfirmationResponseSemantics({
+            selectedOptionId: CONFIRMATION_OPTIONS.YES,
+            attachments: undefined,
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test('rejects YES with attachments', () => {
+        const result = validateConfirmationResponseSemantics({
+            selectedOptionId: CONFIRMATION_OPTIONS.YES,
+            attachments: [{ path: '/tmp/x.txt' }],
+        });
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+            expect(result.reason).toMatch(/attach/i);
+            expect(result.reason).toMatch(/approv/i);
+        }
+    });
+
+    test('rejects YES_DONT_ASK with attachments', () => {
+        const result = validateConfirmationResponseSemantics({
+            selectedOptionId: CONFIRMATION_OPTIONS.YES_DONT_ASK,
+            attachments: [{ path: '/tmp/x.txt' }],
+        });
+        expect(result.valid).toBe(false);
+    });
+
+    test('accepts an ask_user custom option with attachments (not an approval option)', () => {
+        // ask_user uses 'acknowledge' / 'option_N' which are not approval IDs,
+        // so attachments are still allowed and surface via the response's own
+        // handler path.
+        const result = validateConfirmationResponseSemantics({
+            selectedOptionId: 'option_0',
+            attachments: [{ path: '/tmp/x.txt' }],
+        });
+        expect(result.valid).toBe(true);
+    });
+});

--- a/tests/server/ws/confirmation_response_handler.test.ts
+++ b/tests/server/ws/confirmation_response_handler.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Wiring-level tests for ConfirmationResponseHandler.
+ *
+ * The pure validator is covered by tests/server/confirmation_semantics.test.ts.
+ * These tests assert the handler actually calls the validator before any
+ * downstream dispatch, so a future refactor that moves the check past
+ * `handleConfirmationResponse` won't pass silently.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import type { ServerWebSocket } from 'bun';
+import { ConfirmationResponseHandler } from '../../../src/server/routes/ws/commands';
+import type { CommandContext } from '../../../src/server/routes/ws/commands';
+import type { ConfirmationResponseCommand } from '../../../src/server/routes/ws/message-types';
+import type { Session } from '../../../src/server/routes/ws/session-state';
+
+interface CtxRecord {
+    sendCalls: Array<{ message: Record<string, unknown>; conversationId: string }>;
+    sendErrorCalls: Array<{ error: string; conversationId?: string }>;
+}
+
+function buildCtx(): { ctx: CommandContext; record: CtxRecord } {
+    const record: CtxRecord = { sendCalls: [], sendErrorCalls: [] };
+    const ctx: CommandContext = {
+        ws: {} as ServerWebSocket<unknown> as CommandContext['ws'],
+        getSessions: () => new Map<string, Session>(),
+        getUser: async () => null,
+        send: (message, conversationId) => {
+            record.sendCalls.push({ message, conversationId });
+        },
+        sendError: (error, conversationId) => {
+            record.sendErrorCalls.push({ error, conversationId });
+        },
+        addSubscription: () => {},
+    };
+    return { ctx, record };
+}
+
+function buildMessage(overrides: Partial<ConfirmationResponseCommand['data']> = {}): ConfirmationResponseCommand {
+    return {
+        type: 'confirmation_response',
+        conversationId: 'conv-1',
+        runId: 'run-1',
+        data: {
+            requestId: 'req-1',
+            selectedOptionId: 'yes',
+            attachments: [{ path: '/tmp/x.txt' }],
+            timestamp: '2026-05-12T00:00:00.000Z',
+            ...overrides,
+        },
+    };
+}
+
+describe('ConfirmationResponseHandler', () => {
+    test('rejects YES + attachments via ctx.sendError and does not dispatch', async () => {
+        const { ctx, record } = buildCtx();
+
+        await ConfirmationResponseHandler.execute(ctx, buildMessage());
+
+        expect(record.sendErrorCalls).toHaveLength(1);
+        expect(record.sendErrorCalls[0]!.conversationId).toBe('conv-1');
+        expect(record.sendErrorCalls[0]!.error).toMatch(/attach/i);
+        expect(record.sendCalls).toHaveLength(0);
+    });
+
+    test('rejects YES_DONT_ASK + attachments', async () => {
+        const { ctx, record } = buildCtx();
+
+        await ConfirmationResponseHandler.execute(
+            ctx,
+            buildMessage({ selectedOptionId: 'yes_dont_ask' }),
+        );
+
+        expect(record.sendErrorCalls).toHaveLength(1);
+    });
+
+    test('does not reject GUIDANCE + attachments at the validation step', async () => {
+        // Without an active bus this still bails (`Confirmation for unknown or
+        // inactive run`), but the failure mode is different from semantic
+        // rejection — sendError is NOT called.
+        const { ctx, record } = buildCtx();
+
+        await ConfirmationResponseHandler.execute(
+            ctx,
+            buildMessage({ selectedOptionId: 'guidance' }),
+        );
+
+        expect(record.sendErrorCalls).toHaveLength(0);
+    });
+
+    test('does not reject YES with no attachments', async () => {
+        const { ctx, record } = buildCtx();
+
+        await ConfirmationResponseHandler.execute(
+            ctx,
+            buildMessage({ attachments: undefined }),
+        );
+
+        expect(record.sendErrorCalls).toHaveLength(0);
+    });
+});
+

--- a/tests/unit-preload.ts
+++ b/tests/unit-preload.ts
@@ -39,6 +39,7 @@ mock.module(dbSchemaModule, () => {
         McpServer: { $inferSelect: {} },
         Automation: { $inferSelect: {} },
         AutomationExecution: { $inferSelect: {} },
+        PendingConfirmation: { $inferSelect: {} },
         // Sandbox settings table with column references
         SandboxSettings: {
             id: 'id',


### PR DESCRIPTION
## Summary
- `processConfirmationResponse` only appends the attachment block to the denialReason when `!approved`, so a client that sent `selectedOptionId: 'yes'` (or `'yes_dont_ask'`) with attachments had those attachments silently discarded.
- Add `isApprovalOptionId` and `validateConfirmationResponseSemantics` to `src/server/processor/confirmation/confirmation.types.ts` and wire the validator into both transports:
  - **REST** (`routes/automations.ts`): returns **400** with the reason
  - **WS** (`routes/ws/commands/confirmation-response.ts`): logs the rejection and calls `ctx.sendError`, then returns before any downstream dispatch
- Adopt `isApprovalOptionId` at the two other duplicated approval checks (`automation/executor/index.ts:508`, `confirmation.service.ts:175`) so the helper is the single source of truth.
- `ask_user`'s custom option IDs (`acknowledge`, `option_N`) are not approval IDs, so its attachment flow is unaffected.
- JSDoc on `ConfirmationResponse.attachments` documents the rule.

Closes #38

## Why
The client guard at `src/client/app.tsx:1375-1377` already prevents this combination for the GUI, but the server contract was implicit and asymmetric — a programmatic caller (or a future client) sending YES + attachments would see the files vanish with no error or log. The asymmetry is the kind of bug that lies dormant until something changes; making it explicit at the transport boundary removes that risk.

## Test plan
- [x] `bun test tests/server/confirmation_semantics.test.ts` — 8 unit tests covering the pure validator (GUIDANCE/NO/YES/YES_DONT_ASK × with/without attachments, plus `option_0` and `attachments: undefined`)
- [x] `bun test tests/server/ws/confirmation_response_handler.test.ts` — 4 wiring tests asserting the WS handler invokes the validator and short-circuits before `handleConfirmationResponse`
- [x] `bun test tests/server/automations_confirmation_route.test.ts` — 3 REST route tests using Hono's `app.request`, asserting 400 + error body on YES/YES_DONT_ASK + attachments
- [x] `bun test` — full unit suite (514 pass / 10 skip / 0 fail)
- [ ] Smoke-test: trigger a confirmation, click Yes with a file staged (via direct API call since the GUI guards this), confirm REST returns 400

## Notes
- On current `main`, `ctx.sendError` only writes to the server log (a separate open PR teaches it to emit a `run_stopped` frame so the client can clear optimistic state). Until that PR lands the WS-side rejection is logged but not visible to the client. The REST side returns a proper 400 immediately.
- `tests/unit-preload.ts` gains a `PendingConfirmation: { $inferSelect: {} }` line in the schema mock so the automations route can be imported in the new wiring test. Purely additive, matches the existing pattern.