### PR TITLE
Fix blank Linux app window by disabling WebKitGTK DMABUF renderer

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -421,6 +421,19 @@ fn is_process_alive(pid: u32) -> bool {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // WebKitGTK 2.42+ defaults to a DMA-BUF renderer that fails to paint on many
+    // Linux GPU stacks, leaving a blank/white window that only a manual reload
+    // recovers (tauri-apps/tauri#13885, #9394). Force the legacy rendering paths
+    // before GTK initializes. The accepted workaround disables both the DMA-BUF
+    // renderer and accelerated compositing together. Each is set only when unset
+    // so a user can still override it.
+    #[cfg(target_os = "linux")]
+    for var in ["WEBKIT_DISABLE_DMABUF_RENDERER", "WEBKIT_DISABLE_COMPOSITING_MODE"] {
+        if std::env::var_os(var).is_none() {
+            std::env::set_var(var, "1");
+        }
+    }
+
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     tauri::Builder::default()


### PR DESCRIPTION
## What

Set both `WEBKIT_DISABLE_DMABUF_RENDERER=1` and `WEBKIT_DISABLE_COMPOSITING_MODE=1` at startup (Linux only, before GTK/WebKit initialize) to force WebKitGTK's legacy rendering paths.

## Why

WebKitGTK 2.42+ defaults to a DMA-BUF based GPU renderer (and accelerated compositing) that fails to produce a first paint on many Linux GPU stacks — notably Arch and other non-Ubuntu/Debian setups. The window comes up blank/white and only a manual reload recovers it. This is the cross-distro blank-screen reported in #21, matching upstream [tauri-apps/tauri#13885](https://github.com/tauri-apps/tauri/issues/13885) and [#9394](https://github.com/tauri-apps/tauri/issues/9394).

The accepted community workaround (e.g. Tolaria, yaak) disables **both** paths together: the compositing failure produces the same blank window on X11 (`AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer`) that the DMA-BUF flag alone misses. The WebKitGTK maintainer (Igalia) endorses `WEBKIT_DISABLE_DMABUF_RENDERER=1` as the first-line fix on [WebKit Bugzilla #261874](https://bugs.webkit.org/show_bug.cgi?id=261874).

Each var is set only when unset, so a user can still override it and it is scoped to Linux, so no effect on macOS/Windows.

## Testing

- Builds clean (`cargo check`).
- Needs verification on Arch where the blank screen reproduces.

## Scope / follow-up

This addresses the **rendering** layer of #21 only. 

The `Could not create default EGL display: EGL_BAD_PARAMETER` failure is a **distinct** problem — the AppImage bundling the build host's GPU libraries (`mesa`/`libEGL`/`libGL`/`libwayland`) that clash with the target distro's drivers. These env var based changes do **not** fix that.

If we still see `EGL_BAD_PARAMETER`, the follow-up is to exclude/replace those host GPU libraries in the AppImage build (slots into the existing `repackAppImageWithPristineSidecars` step), or pin `libwebkit2gtk` to a known-good version.