### PR TITLE
Add MCP Tool Search to Manage Context Effectively

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "mammoth": "^1.11.0",
         "minimatch": "^10.0.0",
         "officeparser": "^5.2.2",
-        "openai": "^6.16.0",
+        "openai": "^6.46.0",
         "pdf-parse": "^1.1.4",
         "pg": "^8.16.3",
         "pino": "^10.1.0",
@@ -964,7 +964,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "openai": ["openai@6.16.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-fZ1uBqjFUjXzbGc35fFtYKEOxd20kd9fDpFeqWtsOZWiubY8CZ1NAlXHW3iathaFvqmNtCWMIsosCuyeI7Joxg=="],
+    "openai": ["openai@6.46.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA=="],
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 

--- a/drizzle/0023_bitter_squirrel_girl.sql
+++ b/drizzle/0023_bitter_squirrel_girl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "chat_model" ADD COLUMN "supports_tool_search" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0023_snapshot.json
+++ b/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,2166 @@
+{
+  "id": "aa3123a0-643c-43f7-87db-dd816ddbbf16",
+  "prevId": "b415be56-4a55-4284-aeb8-4475f28a6fa5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_model_api": {
+      "name": "ai_model_api",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_key_user_id_user_id_fk": {
+          "name": "api_key_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_token_unique": {
+          "name": "api_key_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation": {
+      "name": "automation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "trigger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_executions_per_day": {
+          "name": "max_executions_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_executions_per_hour": {
+          "name": "max_executions_per_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_scheduled_at": {
+          "name": "next_scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automation_user_id_user_id_fk": {
+          "name": "automation_user_id_user_id_fk",
+          "tableFrom": "automation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automation_conversation_id_conversation_id_fk": {
+          "name": "automation_conversation_id_conversation_id_fk",
+          "tableFrom": "automation",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_execution": {
+      "name": "automation_execution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "trigger_data": {
+          "name": "trigger_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trajectory": {
+          "name": "trajectory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automation_execution_automation_id_automation_id_fk": {
+          "name": "automation_execution_automation_id_automation_id_fk",
+          "tableFrom": "automation_execution",
+          "tableTo": "automation",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_model": {
+      "name": "chat_model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "max_prompt_size": {
+          "name": "max_prompt_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenizer": {
+          "name": "tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gemini-2.5-flash'"
+        },
+        "friendly_name": {
+          "name": "friendly_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "chat_model_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google'"
+        },
+        "vision_enabled": {
+          "name": "vision_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_responses_api": {
+          "name": "use_responses_api",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "supports_tool_search": {
+          "name": "supports_tool_search",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_model_api_id": {
+          "name": "ai_model_api_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_cost_per_million": {
+          "name": "input_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_cost_per_million": {
+          "name": "output_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_cost_per_million": {
+          "name": "cache_read_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_write_cost_per_million": {
+          "name": "cache_write_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "chat_model_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_tier": {
+          "name": "cost_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended": {
+          "name": "recommended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_model_ai_model_api_id_ai_model_api_id_fk": {
+          "name": "chat_model_ai_model_api_id_ai_model_api_id_fk",
+          "tableFrom": "chat_model",
+          "tableTo": "ai_model_api",
+          "columnsFrom": [
+            "ai_model_api_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ATIF-v1.4'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent": {
+          "name": "agent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_metrics": {
+          "name": "final_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_model_id": {
+          "name": "chat_model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_user_id_user_id_fk": {
+          "name": "conversation_user_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_chat_model_id_chat_model_id_fk": {
+          "name": "conversation_chat_model_id_chat_model_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "chat_model",
+          "columnsFrom": [
+            "chat_model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_step": {
+      "name": "conversation_step",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_preview": {
+          "name": "message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step": {
+          "name": "step",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_step_conversation_id_idx": {
+          "name": "conversation_step_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_step_source_idx": {
+          "name": "conversation_step_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_step_conversation_id_conversation_id_fk": {
+          "name": "conversation_step_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_step",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_step_conversation_id_step_id_pk": {
+          "name": "conversation_step_conversation_id_step_id_pk",
+          "columns": [
+            "conversation_id",
+            "step_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_user": {
+      "name": "google_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "azp": {
+          "name": "azp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "google_user_user_id_user_id_fk": {
+          "name": "google_user_user_id_user_id_fk",
+          "tableFrom": "google_user",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_state": {
+      "name": "mcp_oauth_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_server_url": {
+          "name": "authorization_server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_metadata_url": {
+          "name": "resource_metadata_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_url": {
+          "name": "resource_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_information": {
+          "name": "client_information",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_authorization_url": {
+          "name": "last_authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_state_server_id_unique": {
+          "name": "mcp_oauth_state_server_id_unique",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_state_server_id_mcp_server_id_fk": {
+          "name": "mcp_oauth_state_server_id_mcp_server_id_fk",
+          "tableFrom": "mcp_oauth_state",
+          "tableTo": "mcp_server",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server": {
+      "name": "mcp_server",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transport_type": {
+          "name": "transport_type",
+          "type": "mcp_transport_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "mcp_auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "oauth_status": {
+          "name": "oauth_status",
+          "type": "mcp_oauth_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_connected'"
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_mode": {
+          "name": "confirmation_mode",
+          "type": "mcp_confirmation_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'always'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_connected_at": {
+          "name": "last_connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled_tools": {
+          "name": "enabled_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_server_name_unique": {
+          "name": "mcp_server_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_confirmation": {
+      "name": "pending_confirmation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "confirmation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pending_confirmation_execution_id_automation_execution_id_fk": {
+          "name": "pending_confirmation_execution_id_automation_execution_id_fk",
+          "tableFrom": "pending_confirmation",
+          "tableTo": "automation_execution",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_auth": {
+      "name": "platform_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_email": {
+          "name": "platform_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_name": {
+          "name": "platform_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_url": {
+          "name": "platform_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "platform_auth_user_id_user_id_fk": {
+          "name": "platform_auth_user_id_user_id_fk",
+          "tableFrom": "platform_auth",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_settings": {
+      "name": "sandbox_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allowed_write_paths": {
+          "name": "allowed_write_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "denied_write_paths": {
+          "name": "denied_write_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "denied_read_paths": {
+          "name": "denied_read_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_domains": {
+          "name": "allowed_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"*\"]'::jsonb"
+        },
+        "allow_local_binding": {
+          "name": "allow_local_binding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sandbox_settings_user_id_user_id_fk": {
+          "name": "sandbox_settings_user_id_user_id_fk",
+          "tableFrom": "sandbox_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sandbox_settings_user_id_unique": {
+          "name": "sandbox_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subscription_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "renewal_date": {
+          "name": "renewal_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled_trial_at": {
+          "name": "enabled_trial_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_phone_number": {
+          "name": "verified_phone_number",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_email": {
+          "name": "verified_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "account_verification_code": {
+          "name": "account_verification_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_verification_code_expiry": {
+          "name": "account_verification_code_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_uuid_unique": {
+          "name": "user_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_chat_model": {
+      "name": "user_chat_model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_chat_model_user_id_user_id_fk": {
+          "name": "user_chat_model_user_id_user_id_fk",
+          "tableFrom": "user_chat_model",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_chat_model_model_id_chat_model_id_fk": {
+          "name": "user_chat_model_model_id_chat_model_id_fk",
+          "tableFrom": "user_chat_model",
+          "tableTo": "chat_model",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.web_scraper": {
+      "name": "web_scraper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "web_scraper_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.web_search_provider": {
+      "name": "web_search_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "web_search_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personality": {
+          "name": "personality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tools": {
+          "name": "input_tools",
+          "type": "input_tool[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_modes": {
+          "name": "output_modes",
+          "type": "output_mode[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_by_admin": {
+          "name": "managed_by_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chat_model_id": {
+          "name": "chat_model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "style_color": {
+          "name": "style_color",
+          "type": "style_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'orange'"
+        },
+        "style_icon": {
+          "name": "style_icon",
+          "type": "style_icon",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Lightbulb'"
+        },
+        "privacy_level": {
+          "name": "privacy_level",
+          "type": "privacy_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_creator_id_user_id_fk": {
+          "name": "agents_creator_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_chat_model_id_chat_model_id_fk": {
+          "name": "agents_chat_model_id_chat_model_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "chat_model",
+          "columnsFrom": [
+            "chat_model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_slug_unique": {
+          "name": "agents_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.automation_status": {
+      "name": "automation_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "disabled"
+      ]
+    },
+    "public.chat_model_tier": {
+      "name": "chat_model_tier",
+      "schema": "public",
+      "values": [
+        "flagship",
+        "balanced",
+        "lite"
+      ]
+    },
+    "public.chat_model_type": {
+      "name": "chat_model_type",
+      "schema": "public",
+      "values": [
+        "openai",
+        "anthropic",
+        "google"
+      ]
+    },
+    "public.confirmation_status": {
+      "name": "confirmation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied",
+        "expired"
+      ]
+    },
+    "public.execution_status": {
+      "name": "execution_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "awaiting_confirmation",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.mcp_auth_type": {
+      "name": "mcp_auth_type",
+      "schema": "public",
+      "values": [
+        "none",
+        "bearer",
+        "oauth"
+      ]
+    },
+    "public.mcp_confirmation_mode": {
+      "name": "mcp_confirmation_mode",
+      "schema": "public",
+      "values": [
+        "always",
+        "unsafe_only",
+        "never"
+      ]
+    },
+    "public.mcp_oauth_status": {
+      "name": "mcp_oauth_status",
+      "schema": "public",
+      "values": [
+        "not_connected",
+        "auth_pending",
+        "connected",
+        "auth_required",
+        "error"
+      ]
+    },
+    "public.mcp_transport_type": {
+      "name": "mcp_transport_type",
+      "schema": "public",
+      "values": [
+        "stdio",
+        "http"
+      ]
+    },
+    "public.subscription_type": {
+      "name": "subscription_type",
+      "schema": "public",
+      "values": [
+        "free",
+        "premium"
+      ]
+    },
+    "public.trigger_type": {
+      "name": "trigger_type",
+      "schema": "public",
+      "values": [
+        "cron",
+        "file_watch"
+      ]
+    },
+    "public.web_scraper_type": {
+      "name": "web_scraper_type",
+      "schema": "public",
+      "values": [
+        "exa",
+        "direct",
+        "platform"
+      ]
+    },
+    "public.web_search_provider_type": {
+      "name": "web_search_provider_type",
+      "schema": "public",
+      "values": [
+        "exa",
+        "serper",
+        "platform"
+      ]
+    },
+    "public.input_tool": {
+      "name": "input_tool",
+      "schema": "public",
+      "values": [
+        "general",
+        "online",
+        "notes",
+        "webpage",
+        "code"
+      ]
+    },
+    "public.output_mode": {
+      "name": "output_mode",
+      "schema": "public",
+      "values": [
+        "image",
+        "diagram"
+      ]
+    },
+    "public.privacy_level": {
+      "name": "privacy_level",
+      "schema": "public",
+      "values": [
+        "public",
+        "private",
+        "protected"
+      ]
+    },
+    "public.style_color": {
+      "name": "style_color",
+      "schema": "public",
+      "values": [
+        "blue",
+        "green",
+        "red",
+        "yellow",
+        "orange",
+        "purple",
+        "pink",
+        "teal",
+        "cyan",
+        "lime",
+        "indigo",
+        "fuchsia",
+        "rose",
+        "sky",
+        "amber",
+        "emerald"
+      ]
+    },
+    "public.style_icon": {
+      "name": "style_icon",
+      "schema": "public",
+      "values": [
+        "Lightbulb",
+        "Health",
+        "Robot",
+        "Aperture",
+        "GraduationCap",
+        "Jeep",
+        "Island",
+        "MathOperations",
+        "Asclepius",
+        "Couch",
+        "Code",
+        "Atom",
+        "ClockCounterClockwise",
+        "PencilLine",
+        "Chalkboard",
+        "Cigarette",
+        "CraneTower",
+        "Heart",
+        "Leaf",
+        "NewspaperClipping",
+        "OrangeSlice",
+        "SmileyMelting",
+        "YinYang",
+        "SneakerMove",
+        "Student",
+        "Oven",
+        "Gavel",
+        "Broadcast"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1783678451338,
       "tag": "0022_material_king_bedlam",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1783723955432,
+      "tag": "0023_bitter_squirrel_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "mammoth": "^1.11.0",
     "minimatch": "^10.0.0",
     "officeparser": "^5.2.2",
-    "openai": "^6.16.0",
+    "openai": "^6.46.0",
     "pdf-parse": "^1.1.4",
     "pg": "^8.16.3",
     "pino": "^10.1.0",

--- a/src/server/auth/index.ts
+++ b/src/server/auth/index.ts
@@ -442,6 +442,7 @@ export async function syncPlatformModels(): Promise<void> {
             modelType: 'openai' | 'anthropic' | 'google';
             visionEnabled: boolean;
             useResponsesApi: boolean;
+            supportsToolSearch?: boolean;
             inputCostPerMillion: number;
             outputCostPerMillion: number;
             tier: 'flagship' | 'balanced' | 'lite' | null;
@@ -506,6 +507,7 @@ export async function syncPlatformModels(): Promise<void> {
             const modelType = model.modelType;
             const visionEnabled = model.visionEnabled;
             const useResponsesApi = model.useResponsesApi;
+            const supportsToolSearch = model.supportsToolSearch ?? false;
             const friendlyName = model.name || model.id;
             const inputCostPerMillion = model.inputCostPerMillion ?? null;
             const outputCostPerMillion = model.outputCostPerMillion ?? null;
@@ -521,6 +523,7 @@ export async function syncPlatformModels(): Promise<void> {
                     modelType,
                     visionEnabled,
                     useResponsesApi,
+                    supportsToolSearch,
                     inputCostPerMillion,
                     outputCostPerMillion,
                     tier,
@@ -540,6 +543,7 @@ export async function syncPlatformModels(): Promise<void> {
                         existingModel.modelType !== modelType ||
                         existingModel.visionEnabled !== visionEnabled ||
                         existingModel.useResponsesApi !== useResponsesApi ||
+                        existingModel.supportsToolSearch !== supportsToolSearch ||
                         existingModel.inputCostPerMillion !== inputCostPerMillion ||
                         existingModel.outputCostPerMillion !== outputCostPerMillion ||
                         existingModel.tier !== tier ||
@@ -555,6 +559,7 @@ export async function syncPlatformModels(): Promise<void> {
                                 modelType,
                                 visionEnabled,
                                 useResponsesApi,
+                                supportsToolSearch,
                                 inputCostPerMillion,
                                 outputCostPerMillion,
                                 tier,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -154,6 +154,8 @@ export const ChatModel = pgTable('chat_model', {
     modelType: ChatModelTypeEnum('model_type').default('google').notNull(),
     visionEnabled: boolean('vision_enabled').default(false).notNull(),
     useResponsesApi: boolean('use_responses_api').default(false).notNull(),
+    // Model supports native tool search with deferred tool loading
+    supportsToolSearch: boolean('supports_tool_search').default(false).notNull(),
     aiModelApiId: integer('ai_model_api_id').references(() => AiModelApi.id, { onDelete: 'cascade' }),
     // Token Cost (USD) for Usage Tracking
     inputCostPerMillion: real('input_cost_per_million'),

--- a/src/server/processor/actor/search_tools.ts
+++ b/src/server/processor/actor/search_tools.ts
@@ -1,0 +1,154 @@
+/**
+ * Tool Search Actor
+ *
+ * Lets the agent discover MCP tools on demand instead of loading every tool
+ * schema into context upfront. When many MCP tools are connected, only a
+ * compact name index is advertised (in this tool's description); the agent
+ * searches by regex to load full tool definitions into its tool list.
+ *
+ * Mirrors the client-executed tool search pattern in the OpenAI Responses API
+ * and Anthropic Messages API * (`tool_search(_tool_*)` + `defer_loading`).
+ */
+
+import type { ToolDefinition } from '../conversation/conversation';
+import { parseNamespacedToolName } from '../mcp';
+
+/**
+ * Defer MCP tool schemas behind search when more than this many are connected.
+ * Set above the default install's tool count (chrome-browser seeds 17 enabled
+ * tools) so deferral only engages once additional servers are connected.
+ */
+export const MCP_TOOL_DEFER_THRESHOLD = 30;
+
+export const SEARCH_TOOLS_TOOL_NAME = 'search_tools';
+
+const MAX_SEARCH_RESULTS = 15;
+const MAX_RESULT_DESCRIPTION_CHARS = 500;
+const MAX_PATTERN_CHARS = 200;
+
+export interface SearchToolsArgs {
+    /** Regex pattern matched case-insensitively against tool names and descriptions */
+    query: string;
+    /** Restrict the search to tools from this MCP server */
+    server?: string;
+}
+
+export interface SearchToolsResult {
+    compiled: string;
+    matches: ToolDefinition[];
+}
+
+/** Group namespaced tool names by server into a compact one-line-per-server index */
+function buildToolIndex(mcpTools: ToolDefinition[]): string {
+    const byServer = new Map<string, string[]>();
+    for (const tool of mcpTools) {
+        const parsed = parseNamespacedToolName(tool.name);
+        const server = parsed?.serverName ?? 'other';
+        const names = byServer.get(server) ?? [];
+        names.push(parsed?.toolName ?? tool.name);
+        byServer.set(server, names);
+    }
+    return Array.from(byServer.entries())
+        .map(([server, names]) => `- ${server}: ${names.join(', ')}`)
+        .join('\n');
+}
+
+/**
+ * Build the search_tools ToolDefinition. The description carries a name-only
+ * index of every deferrable tool, so the model knows what is discoverable
+ * without paying for full schemas upfront. The index is built from the full
+ * MCP tool set (not just unloaded tools) to keep the description stable
+ * across iterations, preserving the prompt prefix cache.
+ */
+export function buildSearchToolsDefinition(mcpTools: ToolDefinition[]): ToolDefinition {
+    return {
+        name: SEARCH_TOOLS_TOOL_NAME,
+        description: `Search the catalog of connected external (MCP) tools and load the ones you need.
+
+Most external tools are not given to you upfront to keep your context lean. Search by regular expression to load their full definitions; matched tools become available to call from your next step onwards.
+
+Tools available to discover, by server:
+${buildToolIndex(mcpTools)}`,
+        schema: {
+            type: 'object',
+            properties: {
+                query: {
+                    type: 'string',
+                    description: 'Regular expression matched case-insensitively against tool names and descriptions. Examples: "issue" substring, "create_.*_issue" wildcard, "issue|ticket|bug" alternation.',
+                },
+                server: {
+                    type: 'string',
+                    description: 'Optional. Restrict the search to tools from this server.',
+                },
+            },
+            required: ['query'],
+        },
+    };
+}
+
+/** Regex search over MCP tool names and descriptions */
+export function searchTools(args: SearchToolsArgs, mcpTools: ToolDefinition[]): SearchToolsResult {
+    const pattern = (args.query ?? '').trim();
+    if (!pattern) {
+        return { compiled: 'No search pattern provided. Pass a regular expression to match against tool names and descriptions.', matches: [] };
+    }
+    if (pattern.length > MAX_PATTERN_CHARS) {
+        return { compiled: `Search pattern exceeds ${MAX_PATTERN_CHARS} characters. Use a shorter regular expression.`, matches: [] };
+    }
+
+    let regex: RegExp;
+    try {
+        regex = new RegExp(pattern, 'i');
+    } catch (error) {
+        return {
+            compiled: `Invalid regular expression "${pattern}": ${error instanceof Error ? error.message : String(error)}. Fix the pattern and search again.`,
+            matches: [],
+        };
+    }
+
+    const candidates = args.server
+        ? mcpTools.filter(t => parseNamespacedToolName(t.name)?.serverName === args.server)
+        : mcpTools;
+
+    const allMatches = candidates.filter(tool => regex.test(`${tool.name} ${tool.description ?? ''}`));
+    const matches = allMatches.slice(0, MAX_SEARCH_RESULTS);
+
+    if (matches.length === 0) {
+        const scope = args.server ? ` on server "${args.server}"` : '';
+        return {
+            compiled: `No tools matched /${args.query}/i${scope}. Try a broader pattern, or check the tool index in the search_tools description.`,
+            matches: [],
+        };
+    }
+
+    const listing = matches
+        .map(tool => {
+            const description = (tool.description ?? '').slice(0, MAX_RESULT_DESCRIPTION_CHARS);
+            return `- ${tool.name}: ${description}`;
+        })
+        .join('\n');
+
+    const omitted = allMatches.length - matches.length;
+    const omittedNote = omitted > 0 ? `\n(${omitted} more matches omitted; refine the pattern to see them.)` : '';
+
+    return {
+        compiled: `Found ${matches.length} matching tool(s):\n${listing}${omittedNote}\n\nThese tools are now loaded and available to call from your next step.`,
+        matches,
+    };
+}
+
+/**
+ * Replace the full MCP tool list with the search_tools definition plus any
+ * already-loaded tools. Below the threshold all tools pass through unchanged
+ * and no search tool is advertised.
+ */
+export function applyToolDeferral(
+    mcpTools: ToolDefinition[],
+    loadedToolNames: Set<string>
+): ToolDefinition[] {
+    if (mcpTools.length <= MCP_TOOL_DEFER_THRESHOLD) {
+        return mcpTools;
+    }
+    const loaded = mcpTools.filter(t => loadedToolNames.has(t.name));
+    return [buildSearchToolsDefinition(mcpTools), ...loaded];
+}

--- a/src/server/processor/actor/search_tools.ts
+++ b/src/server/processor/actor/search_tools.ts
@@ -138,6 +138,64 @@ export function searchTools(args: SearchToolsArgs, mcpTools: ToolDefinition[]): 
 }
 
 /**
+ * Provider-executed variant of tool deferral for models that support tool
+ * search (OpenAI gpt-5.4+, Anthropic Claude via platform translation): all MCP
+ * tools are sent marked defer_loading alongside a provider-native tool_search
+ * tool. The provider hides deferred schemas from model context, executes
+ * searches server-side (no app round-trip), and injects matches at the end of
+ * context — deferral state rides in the conversation's raw item history.
+ *
+ * With `namespaced` (models with tool search over the OpenAI Responses API),
+ * each MCP server becomes a namespace tool holding its tools as deferred
+ * children, per the OpenAI tool search guidance — the model sees server names
+ * and descriptions upfront and can load a whole server via one search. The
+ * model then calls tools with a bare name plus a separate namespace field;
+ * getFunctionCallName() rejoins them into the server__tool convention.
+ */
+export function applyProviderToolSearch(
+    mcpTools: ToolDefinition[],
+    options: { namespaced?: boolean; serverDescriptions?: Map<string, string> } = {}
+): ToolDefinition[] {
+    if (mcpTools.length <= MCP_TOOL_DEFER_THRESHOLD) {
+        return mcpTools;
+    }
+    const searchTool: ToolDefinition = { name: 'tool_search', type: 'tool_search', schema: {} };
+    if (!options.namespaced) {
+        return [searchTool, ...mcpTools.map(tool => ({ ...tool, deferLoading: true }))];
+    }
+
+    // One namespace per MCP server; tools without a server prefix stay flat
+    const byServer = new Map<string, ToolDefinition[]>();
+    const flatTools: ToolDefinition[] = [];
+    for (const tool of mcpTools) {
+        const parsed = parseNamespacedToolName(tool.name);
+        if (!parsed) {
+            flatTools.push({ ...tool, deferLoading: true });
+            continue;
+        }
+        const children = byServer.get(parsed.serverName) ?? [];
+        children.push({
+            name: parsed.toolName,
+            // The [MCP: server] prefix is redundant inside the server's namespace
+            description: tool.description?.replace(`[MCP: ${parsed.serverName}] `, ''),
+            schema: tool.schema,
+            deferLoading: true,
+        });
+        byServer.set(parsed.serverName, children);
+    }
+
+    const namespaces = Array.from(byServer.entries()).map(([server, tools]): ToolDefinition => ({
+        type: 'namespace',
+        name: server,
+        description: options.serverDescriptions?.get(server) ?? `Tools provided by the ${server} MCP server.`,
+        schema: {},
+        tools,
+    }));
+
+    return [searchTool, ...namespaces, ...flatTools];
+}
+
+/**
  * Replace the full MCP tool list with the search_tools definition plus any
  * already-loaded tools. Below the threshold all tools pass through unchanged
  * and no search tool is advertised.

--- a/src/server/processor/conversation/conversation.d.ts
+++ b/src/server/processor/conversation/conversation.d.ts
@@ -34,4 +34,10 @@ export interface ToolDefinition {
     schema: Record<string, any>;
     name: string;
     description?: string;
+    /** 'tool_search' emits a provider-native tool search tool; 'namespace' groups child tools */
+    type?: 'function' | 'tool_search' | 'namespace';
+    /** Defer this tool's schema out of model context until discovered via tool search */
+    deferLoading?: boolean;
+    /** Child tools of a namespace definition */
+    tools?: ToolDefinition[];
 }

--- a/src/server/processor/conversation/openai/utils.ts
+++ b/src/server/processor/conversation/openai/utils.ts
@@ -1,15 +1,45 @@
 import type { ToolDefinition } from "../conversation";
 import type { Responses } from 'openai/resources/responses/responses';
 
-export function toOpenaiTools(tools?: ToolDefinition[]): Responses.FunctionTool[] | undefined {
+export function toOpenaiTools(tools?: ToolDefinition[]): Responses.Tool[] | undefined {
     if (!tools) return undefined;
-    return tools.map((tool) => ({
-        type: "function" as const,
-        name: tool.name,
-        description: tool.description ?? undefined,
-        parameters: tool.schema,
-        strict: false,
-    }));
+    return tools.map((tool): Responses.Tool => {
+        if (tool.type === 'tool_search') {
+            // Provider executes searches over tools marked defer_loading
+            return { type: 'tool_search' };
+        }
+        if (tool.type === 'namespace') {
+            return {
+                type: 'namespace',
+                name: tool.name,
+                description: tool.description ?? '',
+                tools: (tool.tools ?? []).map((child) => ({
+                    type: 'function' as const,
+                    name: child.name,
+                    description: child.description ?? undefined,
+                    parameters: child.schema,
+                    ...(child.deferLoading ? { defer_loading: true } : {}),
+                })),
+            };
+        }
+        return {
+            type: 'function' as const,
+            name: tool.name,
+            description: tool.description ?? undefined,
+            parameters: tool.schema,
+            strict: false,
+            ...(tool.deferLoading ? { defer_loading: true } : {}),
+        };
+    });
+}
+
+/**
+ * Resolve a function call's effective tool name. Calls to tools inside a
+ * namespace carry a bare function name plus a separate namespace field;
+ * rejoin them into the app's server__tool naming convention for routing.
+ */
+export function getFunctionCallName(call: { name: string; namespace?: string | null }): string {
+    return call.namespace ? `${call.namespace}__${call.name}` : call.name;
 }
 
 /**

--- a/src/server/processor/director/index.ts
+++ b/src/server/processor/director/index.ts
@@ -14,6 +14,7 @@ import { readWebpage, type ReadWebpageArgs } from '../actor/read_webpage';
 import { askUser, type AskUserArgs } from '../actor/ask_user';
 import { generateImage, type GenerateImageArgs } from '../actor/generate_image';
 import { emailUser, type EmailUserArgs } from '../actor/email_user';
+import { applyToolDeferral, searchTools, SEARCH_TOOLS_TOOL_NAME, type SearchToolsArgs } from '../actor/search_tools';
 import * as prompts from './prompts';
 import { getLoadedSkills, formatSkillsForPrompt } from '../../skills';
 import { type ATIFMetrics, type ATIFObservationResult, type ATIFToolCall, type ATIFTrajectory } from '../conversation/atif/atif.types';
@@ -137,6 +138,8 @@ interface ResearchConfig {
     conversationId?: string;
     // Callback for real-time text delta streaming
     onTextChunk?: (chunk: string) => void;
+    // MCP tools whose full schemas are advertised to the model (others are deferred behind search_tools)
+    loadedMcpTools?: Set<string>;
 }
 
 export async function buildSystemPrompt(args: {
@@ -513,12 +516,14 @@ Tips:
 ];
 
 /**
- * Get all available tools including built-in tools and MCP tools
+ * Get all available tools including built-in tools and MCP tools.
+ * When many MCP tools are connected, their schemas are deferred behind the
+ * search_tools tool; only tools in `loadedMcpTools` are advertised in full.
  */
-async function getAllTools(): Promise<ToolDefinition[]> {
+async function getAllTools(loadedMcpTools: Set<string> = new Set()): Promise<ToolDefinition[]> {
     try {
         const mcpTools = await getMcpToolDefinitions();
-        return [...builtInTools, ...mcpTools];
+        return [...builtInTools, ...applyToolDeferral(mcpTools, loadedMcpTools)];
     } catch (error) {
         log.error({ err: error }, 'Failed to load MCP tools');
         return builtInTools;
@@ -535,7 +540,7 @@ async function pickNextTool(
     const isLast = currentIteration >= maxIterations - 1;
 
     // Get all tools (built-in + MCP)
-    const tools = await getAllTools();
+    const tools = await getAllTools(config.loadedMcpTools);
     const toolChoice = isLast ? 'none' : 'auto';
 
     const now = new Date();
@@ -741,6 +746,9 @@ async function executeTool(
     try {
         // Check if this is an MCP tool (contains "__" in name, e.g., "github__create_issue")
         if (isMcpTool(toolCall.function_name)) {
+            // Direct calls to deferred tools work without a prior search; mark
+            // them loaded so their schemas are advertised from the next iteration
+            context?.loadedMcpTools?.add(toolCall.function_name);
             return await executeMcpTool(
                 toolCall.function_name,
                 toolCall.arguments as Record<string, unknown>,
@@ -750,6 +758,14 @@ async function executeTool(
 
         // Built-in tools
         switch (toolCall.function_name) {
+            case SEARCH_TOOLS_TOOL_NAME: {
+                const mcpTools = await getMcpToolDefinitions();
+                const result = searchTools(toolCall.arguments as SearchToolsArgs, mcpTools);
+                for (const match of result.matches) {
+                    context?.loadedMcpTools?.add(match.name);
+                }
+                return result.compiled;
+            }
             case 'list_files': {
                 const result = await listFiles(toolCall.arguments as ListFilesArgs);
                 return result.compiled;
@@ -916,6 +932,18 @@ export async function* research(config: ResearchConfig): AsyncGenerator<Research
     // Persists across iterations so one-time reminders only fire once per research run
     const shownReminders = new Set<string>();
 
+    // MCP tools whose schemas are advertised to the model when deferral is active.
+    // Seeded from tools called earlier in the conversation so they stay available
+    // across turns; grows when search_tools finds tools or a deferred tool is called.
+    const loadedMcpTools = new Set<string>(config.loadedMcpTools);
+    for (const step of config.chatHistory.steps) {
+        for (const tc of step.tool_calls ?? []) {
+            if (isMcpTool(tc.function_name)) {
+                loadedMcpTools.add(tc.function_name);
+            }
+        }
+    }
+
     for (let i = 0; i < config.maxIterations; i++) {
         // Check if paused before starting new iteration
         if (config.abortSignal?.aborted) {
@@ -927,7 +955,7 @@ export async function* research(config: ResearchConfig): AsyncGenerator<Research
             thresholdStepCount = config.chatHistory.steps.length;
         }
 
-        const iteration = await pickNextTool({ ...config, currentIteration: i, thresholdStepCount });
+        const iteration = await pickNextTool({ ...config, currentIteration: i, thresholdStepCount, loadedMcpTools });
 
         // Handle warnings (e.g., invalid JSON in tool arguments, API errors) - feed back to model for retry
         // Must check before empty tool calls check, since warnings with no valid tool calls should continue loop
@@ -1047,6 +1075,7 @@ export async function* research(config: ResearchConfig): AsyncGenerator<Research
             conversationId: config.conversationId,
             runId: config.runId,
             shownReminders,
+            loadedMcpTools,
         };
         iteration.toolResults = await executeToolsInParallel(iteration.toolCalls, executionContext, config.abortSignal);
 

--- a/src/server/processor/director/index.ts
+++ b/src/server/processor/director/index.ts
@@ -14,12 +14,14 @@ import { readWebpage, type ReadWebpageArgs } from '../actor/read_webpage';
 import { askUser, type AskUserArgs } from '../actor/ask_user';
 import { generateImage, type GenerateImageArgs } from '../actor/generate_image';
 import { emailUser, type EmailUserArgs } from '../actor/email_user';
-import { applyToolDeferral, searchTools, SEARCH_TOOLS_TOOL_NAME, type SearchToolsArgs } from '../actor/search_tools';
+import { applyProviderToolSearch, applyToolDeferral, searchTools, SEARCH_TOOLS_TOOL_NAME, type SearchToolsArgs } from '../actor/search_tools';
+import { getFunctionCallName } from '../conversation/openai/utils';
+import { getChatModelById, getDefaultChatModel } from '../../db';
 import * as prompts from './prompts';
 import { getLoadedSkills, formatSkillsForPrompt } from '../../skills';
 import { type ATIFMetrics, type ATIFObservationResult, type ATIFToolCall, type ATIFTrajectory } from '../conversation/atif/atif.types';
 import type { ConfirmationContext } from '../confirmation';
-import { getMcpToolDefinitions, executeMcpTool, isMcpTool } from '../mcp';
+import { getMcpToolDefinitions, getMcpServerDescriptions, executeMcpTool, isMcpTool } from '../mcp';
 import { PlatformBillingError } from '../../http/billing-errors';
 import { PlatformAuthError } from '../../http/platform-fetch';
 import { createChildLogger } from '../../logger';
@@ -140,7 +142,13 @@ interface ResearchConfig {
     onTextChunk?: (chunk: string) => void;
     // MCP tools whose full schemas are advertised to the model (others are deferred behind search_tools)
     loadedMcpTools?: Set<string>;
+    // How MCP tools defer for this run: provider tool search ('namespaced' over the
+    // OpenAI Responses API, 'flat' via provider translation) or the app-side
+    // search_tools actor ('off')
+    providerToolSearch?: ProviderToolSearchMode;
 }
+
+export type ProviderToolSearchMode = 'off' | 'flat' | 'namespaced';
 
 export async function buildSystemPrompt(args: {
     currentDate?: string;
@@ -517,16 +525,42 @@ Tips:
 
 /**
  * Get all available tools including built-in tools and MCP tools.
- * When many MCP tools are connected, their schemas are deferred behind the
- * search_tools tool; only tools in `loadedMcpTools` are advertised in full.
+ * When many MCP tools are connected, their schemas are deferred behind tool
+ * search: models with provider tool search get provider-side deferral (MCP tools
+ * marked defer_loading); others get the app-side search_tools actor, where
+ * only tools in `loadedMcpTools` are advertised in full.
  */
-async function getAllTools(loadedMcpTools: Set<string> = new Set()): Promise<ToolDefinition[]> {
+async function getAllTools(loadedMcpTools: Set<string> = new Set(), providerToolSearch: ProviderToolSearchMode = 'off'): Promise<ToolDefinition[]> {
     try {
         const mcpTools = await getMcpToolDefinitions();
-        return [...builtInTools, ...applyToolDeferral(mcpTools, loadedMcpTools)];
+        const deferredMcpTools = providerToolSearch !== 'off'
+            ? applyProviderToolSearch(mcpTools, {
+                namespaced: providerToolSearch === 'namespaced',
+                serverDescriptions: getMcpServerDescriptions(),
+            })
+            : applyToolDeferral(mcpTools, loadedMcpTools);
+        return [...builtInTools, ...deferredMcpTools];
     } catch (error) {
         log.error({ err: error }, 'Failed to load MCP tools');
         return builtInTools;
+    }
+}
+
+/**
+ * How the research run's chat model defers MCP tools. Models with provider
+ * tool search get namespaced grouping when served over the OpenAI Responses
+ * API (passthrough), or flat defer_loading otherwise.
+ */
+async function resolveProviderToolSearchMode(chatModelId?: number, user?: typeof User.$inferSelect): Promise<ProviderToolSearchMode> {
+    try {
+        const chatModelWithApi = chatModelId
+            ? await getChatModelById(chatModelId)
+            : await getDefaultChatModel(user);
+        if (!chatModelWithApi?.chatModel.supportsToolSearch) return 'off';
+        return chatModelWithApi.chatModel.useResponsesApi ? 'namespaced' : 'flat';
+    } catch (error) {
+        log.warn({ err: error }, 'Failed to resolve model tool search capability');
+        return 'off';
     }
 }
 
@@ -540,7 +574,7 @@ async function pickNextTool(
     const isLast = currentIteration >= maxIterations - 1;
 
     // Get all tools (built-in + MCP)
-    const tools = await getAllTools(config.loadedMcpTools);
+    const tools = await getAllTools(config.loadedMcpTools, config.providerToolSearch);
     const toolChoice = isLast ? 'none' : 'auto';
 
     const now = new Date();
@@ -651,7 +685,7 @@ async function pickNextTool(
             try {
                 const args = typeof fc.arguments === 'string' ? JSON.parse(fc.arguments) : fc.arguments;
                 toolCalls.push({
-                    function_name: fc.name,
+                    function_name: getFunctionCallName(fc),
                     arguments: args,
                     tool_call_id: fc.call_id,
                 });
@@ -932,6 +966,11 @@ export async function* research(config: ResearchConfig): AsyncGenerator<Research
     // Persists across iterations so one-time reminders only fire once per research run
     const shownReminders = new Set<string>();
 
+    // Models with provider tool search defer MCP tools provider-side; others use
+    // the app-side search_tools actor. Resolved once — model is fixed per run.
+    const providerToolSearch = config.providerToolSearch
+        ?? await resolveProviderToolSearchMode(config.chatModelId, config.user);
+
     // MCP tools whose schemas are advertised to the model when deferral is active.
     // Seeded from tools called earlier in the conversation so they stay available
     // across turns; grows when search_tools finds tools or a deferred tool is called.
@@ -955,7 +994,7 @@ export async function* research(config: ResearchConfig): AsyncGenerator<Research
             thresholdStepCount = config.chatHistory.steps.length;
         }
 
-        const iteration = await pickNextTool({ ...config, currentIteration: i, thresholdStepCount, loadedMcpTools });
+        const iteration = await pickNextTool({ ...config, currentIteration: i, thresholdStepCount, loadedMcpTools, providerToolSearch });
 
         // Handle warnings (e.g., invalid JSON in tool arguments, API errors) - feed back to model for retry
         // Must check before empty tool calls check, since warnings with no valid tool calls should continue loop

--- a/src/server/processor/director/types.ts
+++ b/src/server/processor/director/types.ts
@@ -64,4 +64,6 @@ export interface ToolExecutionContext {
     runId?: string;
     /** Tracks one-time reminders shown during this research run (persists across iterations) */
     shownReminders?: Set<string>;
+    /** MCP tools whose full schemas are advertised to the model; search_tools and direct calls add to it */
+    loadedMcpTools?: Set<string>;
 }

--- a/src/server/processor/mcp/client.ts
+++ b/src/server/processor/mcp/client.ts
@@ -283,6 +283,10 @@ export class McpClient {
         return this.config.name;
     }
 
+    get serverDescription(): string | null {
+        return this.config.description ?? null;
+    }
+
     get confirmationMode(): 'always' | 'unsafe_only' | 'never' {
         return this.config.confirmationMode;
     }

--- a/src/server/processor/mcp/index.ts
+++ b/src/server/processor/mcp/index.ts
@@ -10,4 +10,5 @@ export {
     closeMcpClients,
     getMcpServerStatuses,
     isMcpTool,
+    parseNamespacedToolName,
 } from './manager';

--- a/src/server/processor/mcp/index.ts
+++ b/src/server/processor/mcp/index.ts
@@ -5,6 +5,7 @@ export {
     reconnectMcpServer,
     disconnectMcpServer,
     getMcpToolDefinitions,
+    getMcpServerDescriptions,
     executeMcpTool,
     closeMcpClients,
     getMcpServerStatuses,

--- a/src/server/processor/mcp/manager.ts
+++ b/src/server/processor/mcp/manager.ts
@@ -235,6 +235,20 @@ export async function getMcpToolDefinitions(): Promise<ToolDefinition[]> {
 }
 
 /**
+ * Get the configured description of each connected MCP server, by server name.
+ * Used as the namespace description when MCP tools are grouped per server.
+ */
+export function getMcpServerDescriptions(): Map<string, string> {
+    const descriptions = new Map<string, string>();
+    for (const client of activeClients.values()) {
+        if (client.status === 'connected' && client.serverDescription) {
+            descriptions.set(client.serverName, client.serverDescription);
+        }
+    }
+    return descriptions;
+}
+
+/**
  * Augment a tool's input schema with the operation_type property.
  * This property is required for all MCP tool calls so the confirmation system
  * can determine whether confirmation is needed based on server settings.

--- a/tests/server/conversation_messages.test.ts
+++ b/tests/server/conversation_messages.test.ts
@@ -25,11 +25,13 @@ describe('toOpenaiTools', () => {
 
         expect(result).toBeDefined();
         expect(result).toHaveLength(1);
-        expect(result![0]!.type).toBe('function');
-        expect(result![0]!.name).toBe('view_file');
-        expect(result![0]!.description).toBe('Read a file');
-        expect(result![0]!.parameters).toEqual({ type: 'object', properties: { path: { type: 'string' } } });
-        expect(result![0]!.strict).toBe(false);
+        expect(result![0]).toMatchObject({
+            type: 'function',
+            name: 'view_file',
+            description: 'Read a file',
+            parameters: { type: 'object', properties: { path: { type: 'string' } } },
+            strict: false,
+        });
     });
 
     test('should convert multiple tool definitions', () => {
@@ -41,11 +43,10 @@ describe('toOpenaiTools', () => {
         const result = toOpenaiTools(tools);
 
         expect(result).toHaveLength(3);
-        expect(result![0]!.name).toBe('view_file');
-        expect(result![0]!.description).toBeUndefined();
-        expect(result![1]!.name).toBe('edit_file');
-        expect(result![1]!.description).toBe('Edit a file');
-        expect(result![2]!.name).toBe('shell_command');
+        expect(result![0]).toMatchObject({ name: 'view_file' });
+        expect((result![0] as { description?: string }).description).toBeUndefined();
+        expect(result![1]).toMatchObject({ name: 'edit_file', description: 'Edit a file' });
+        expect(result![2]).toMatchObject({ name: 'shell_command' });
     });
 });
 

--- a/tests/server/search_tools.test.ts
+++ b/tests/server/search_tools.test.ts
@@ -1,0 +1,140 @@
+import { test, expect, describe } from 'bun:test';
+import {
+    searchTools,
+    buildSearchToolsDefinition,
+    applyToolDeferral,
+    MCP_TOOL_DEFER_THRESHOLD,
+    SEARCH_TOOLS_TOOL_NAME,
+} from '../../src/server/processor/actor/search_tools';
+import type { ToolDefinition } from '../../src/server/processor/conversation/conversation';
+
+function makeTool(server: string, name: string, description: string): ToolDefinition {
+    return {
+        name: `${server}__${name}`,
+        description: `[MCP: ${server}] ${description}`,
+        schema: { type: 'object', properties: {} },
+    };
+}
+
+const TOOLS: ToolDefinition[] = [
+    makeTool('github', 'create_issue', 'Create a new issue in a GitHub repository'),
+    makeTool('github', 'list_pull_requests', 'List pull requests in a repository'),
+    makeTool('github', 'merge_pull_request', 'Merge an open pull request'),
+    makeTool('linear', 'create_issue', 'Create a new issue in Linear'),
+    makeTool('linear', 'search_issues', 'Search Linear issues by keyword'),
+    makeTool('slack', 'send_message', 'Send a message to a Slack channel'),
+];
+
+describe('searchTools', () => {
+    test('matches tools by substring pattern in name', () => {
+        const result = searchTools({ query: 'issue' }, TOOLS);
+        const names = result.matches.map(t => t.name);
+        expect(names).toContain('github__create_issue');
+        expect(names).toContain('linear__create_issue');
+        expect(names).toContain('linear__search_issues');
+        expect(names).not.toContain('slack__send_message');
+        expect(result.compiled).toContain('github__create_issue');
+    });
+
+    test('matches tools by pattern in description', () => {
+        const result = searchTools({ query: 'channel' }, TOOLS);
+        expect(result.matches.map(t => t.name)).toEqual(['slack__send_message']);
+    });
+
+    test('supports regex wildcards', () => {
+        const result = searchTools({ query: 'merge.*request' }, TOOLS);
+        expect(result.matches.map(t => t.name)).toEqual(['github__merge_pull_request']);
+    });
+
+    test('supports regex alternation', () => {
+        const result = searchTools({ query: 'channel|merge' }, TOOLS);
+        const names = result.matches.map(t => t.name);
+        expect(names).toContain('slack__send_message');
+        expect(names).toContain('github__merge_pull_request');
+        expect(names).toHaveLength(2);
+    });
+
+    test('restricts search to a server when specified', () => {
+        const result = searchTools({ query: 'issue', server: 'linear' }, TOOLS);
+        const names = result.matches.map(t => t.name);
+        expect(names).toContain('linear__create_issue');
+        expect(names.every(n => n.startsWith('linear__'))).toBe(true);
+    });
+
+    test('is case-insensitive', () => {
+        const result = searchTools({ query: 'SLACK' }, TOOLS);
+        expect(result.matches.map(t => t.name)).toContain('slack__send_message');
+    });
+
+    test('reports invalid regex with the parse error', () => {
+        const result = searchTools({ query: '(unclosed' }, TOOLS);
+        expect(result.matches).toEqual([]);
+        expect(result.compiled).toContain('Invalid regular expression');
+    });
+
+    test('rejects patterns over the length limit', () => {
+        const result = searchTools({ query: 'a'.repeat(201) }, TOOLS);
+        expect(result.matches).toEqual([]);
+        expect(result.compiled).toContain('exceeds 200 characters');
+    });
+
+    test('reports no matches gracefully', () => {
+        const result = searchTools({ query: 'quantum_teleportation' }, TOOLS);
+        expect(result.matches).toEqual([]);
+        expect(result.compiled).toContain('No tools matched');
+    });
+
+    test('handles empty query gracefully', () => {
+        const result = searchTools({ query: '   ' }, TOOLS);
+        expect(result.matches).toEqual([]);
+        expect(result.compiled).toContain('No search pattern');
+    });
+
+    test('tells the model matched tools are now available', () => {
+        const result = searchTools({ query: 'slack' }, TOOLS);
+        expect(result.compiled).toContain('now loaded');
+    });
+});
+
+describe('buildSearchToolsDefinition', () => {
+    test('indexes tool names grouped by server', () => {
+        const definition = buildSearchToolsDefinition(TOOLS);
+        expect(definition.name).toBe(SEARCH_TOOLS_TOOL_NAME);
+        expect(definition.description).toContain('- github: create_issue, list_pull_requests, merge_pull_request');
+        expect(definition.description).toContain('- linear: create_issue, search_issues');
+        expect(definition.description).toContain('- slack: send_message');
+        expect(definition.schema.required).toEqual(['query']);
+    });
+});
+
+describe('applyToolDeferral', () => {
+    const manyTools = Array.from({ length: MCP_TOOL_DEFER_THRESHOLD + 5 }, (_, i) =>
+        makeTool('server', `tool_${i}`, `Tool number ${i}`)
+    );
+
+    test('passes all tools through below the threshold', () => {
+        const few = TOOLS.slice(0, 3);
+        const result = applyToolDeferral(few, new Set());
+        expect(result).toEqual(few);
+        expect(result.some(t => t.name === SEARCH_TOOLS_TOOL_NAME)).toBe(false);
+    });
+
+    test('defers all tools behind search_tools above the threshold', () => {
+        const result = applyToolDeferral(manyTools, new Set());
+        expect(result).toHaveLength(1);
+        expect(result[0]?.name).toBe(SEARCH_TOOLS_TOOL_NAME);
+    });
+
+    test('advertises loaded tools alongside search_tools', () => {
+        const loaded = new Set(['server__tool_3', 'server__tool_7']);
+        const result = applyToolDeferral(manyTools, loaded);
+        expect(result.map(t => t.name)).toEqual([SEARCH_TOOLS_TOOL_NAME, 'server__tool_3', 'server__tool_7']);
+    });
+
+    test('keeps the search_tools index stable as tools are loaded', () => {
+        const before = applyToolDeferral(manyTools, new Set())[0]?.description;
+        const after = applyToolDeferral(manyTools, new Set(['server__tool_3']))[0]?.description;
+        expect(before).toBeDefined();
+        expect(after).toBe(before!);
+    });
+});

--- a/tests/server/search_tools.test.ts
+++ b/tests/server/search_tools.test.ts
@@ -3,9 +3,11 @@ import {
     searchTools,
     buildSearchToolsDefinition,
     applyToolDeferral,
+    applyProviderToolSearch,
     MCP_TOOL_DEFER_THRESHOLD,
     SEARCH_TOOLS_TOOL_NAME,
 } from '../../src/server/processor/actor/search_tools';
+import { toOpenaiTools, getFunctionCallName } from '../../src/server/processor/conversation/openai/utils';
 import type { ToolDefinition } from '../../src/server/processor/conversation/conversation';
 
 function makeTool(server: string, name: string, description: string): ToolDefinition {
@@ -131,10 +133,100 @@ describe('applyToolDeferral', () => {
         expect(result.map(t => t.name)).toEqual([SEARCH_TOOLS_TOOL_NAME, 'server__tool_3', 'server__tool_7']);
     });
 
+    test('provider: passes all tools through below the threshold', () => {
+        const few = TOOLS.slice(0, 3);
+        expect(applyProviderToolSearch(few)).toEqual(few);
+        expect(applyProviderToolSearch(few, { namespaced: true })).toEqual(few);
+    });
+
+    test('provider: defers all tools with a provider tool_search entry above the threshold', () => {
+        const result = applyProviderToolSearch(manyTools);
+        expect(result[0]?.type).toBe('tool_search');
+        expect(result).toHaveLength(manyTools.length + 1);
+        expect(result.slice(1).every(t => t.deferLoading === true)).toBe(true);
+    });
+
+    test('provider namespaced: groups tools into one namespace per server', () => {
+        const multiServer = [
+            ...Array.from({ length: MCP_TOOL_DEFER_THRESHOLD }, (_, i) => makeTool('github', `tool_${i}`, `GitHub tool ${i}`)),
+            makeTool('slack', 'send_message', 'Send a message to a Slack channel'),
+        ];
+        const result = applyProviderToolSearch(multiServer, {
+            namespaced: true,
+            serverDescriptions: new Map([['github', 'Manage GitHub repositories, issues and pull requests.']]),
+        });
+
+        expect(result[0]?.type).toBe('tool_search');
+        const namespaces = result.filter(t => t.type === 'namespace');
+        expect(namespaces.map(n => n.name)).toEqual(['github', 'slack']);
+        // Configured server description is used; servers without one get a generic fallback
+        expect(namespaces[0]?.description).toBe('Manage GitHub repositories, issues and pull requests.');
+        expect(namespaces[1]?.description).toBe('Tools provided by the slack MCP server.');
+
+        const github = namespaces[0]!;
+        expect(github.tools).toHaveLength(MCP_TOOL_DEFER_THRESHOLD);
+        // Children carry bare names, deferred schemas, and no redundant server prefix
+        expect(github.tools?.[0]).toMatchObject({ name: 'tool_0', deferLoading: true, description: 'GitHub tool 0' });
+        // Namespaces themselves are not deferred
+        expect(namespaces.every(n => n.deferLoading === undefined)).toBe(true);
+    });
+
     test('keeps the search_tools index stable as tools are loaded', () => {
         const before = applyToolDeferral(manyTools, new Set())[0]?.description;
         const after = applyToolDeferral(manyTools, new Set(['server__tool_3']))[0]?.description;
         expect(before).toBeDefined();
         expect(after).toBe(before!);
+    });
+});
+
+describe('toOpenaiTools provider tool search mapping', () => {
+    test('maps tool_search type to a provider tool_search tool', () => {
+        const [mapped] = toOpenaiTools([{ name: 'tool_search', type: 'tool_search', schema: {} }]) ?? [];
+        expect(mapped).toEqual({ type: 'tool_search' });
+    });
+
+    test('maps deferLoading to defer_loading on function tools', () => {
+        const tool = makeTool('github', 'create_issue', 'Create an issue');
+        const [mapped] = toOpenaiTools([{ ...tool, deferLoading: true }]) ?? [];
+        expect(mapped).toMatchObject({ type: 'function', name: tool.name, defer_loading: true });
+    });
+
+    test('omits defer_loading on regular function tools', () => {
+        const [mapped] = toOpenaiTools([makeTool('github', 'create_issue', 'Create an issue')]) ?? [];
+        expect(mapped).toMatchObject({ type: 'function' });
+        expect(mapped && 'defer_loading' in mapped).toBe(false);
+    });
+
+    test('maps namespace definitions with deferred children', () => {
+        const [mapped] = toOpenaiTools([{
+            type: 'namespace',
+            name: 'github',
+            description: 'Tools provided by the github MCP server.',
+            schema: {},
+            tools: [{ name: 'create_issue', description: 'Create an issue', schema: { type: 'object' }, deferLoading: true }],
+        }]) ?? [];
+        expect(mapped).toEqual({
+            type: 'namespace',
+            name: 'github',
+            description: 'Tools provided by the github MCP server.',
+            tools: [{
+                type: 'function',
+                name: 'create_issue',
+                description: 'Create an issue',
+                parameters: { type: 'object' },
+                defer_loading: true,
+            }],
+        });
+    });
+});
+
+describe('getFunctionCallName', () => {
+    test('rejoins namespaced calls into the server__tool convention', () => {
+        expect(getFunctionCallName({ name: 'create_issue', namespace: 'github' })).toBe('github__create_issue');
+    });
+
+    test('passes plain calls through unchanged', () => {
+        expect(getFunctionCallName({ name: 'search_web' })).toBe('search_web');
+        expect(getFunctionCallName({ name: 'github__create_issue', namespace: null })).toBe('github__create_issue');
     });
 });


### PR DESCRIPTION
### Overview

Exposes an MCP tool search tool when number of MCP tools increase above a threshold (30 tools). 
This improves Pipali's per task cost and effectiveness even with a bunch of MCP servers enabled.

### Details

The MCP tools search enables Pipali to load tools it needs using regex search for tools across enabled MCP servers.
MCP tool search leverages ai provider side tool search tool when available, like those exposed by models served by the official Openai and Anthropic API.

### Testing

Verified enabled behavior, specifically a MCP tool search is exposed when MCP tools count cross threshold. And Pipali is able to use the MCP tool search to find and use required (MCP) tools to complete its task.