### PR TITLE
Fix blank Linux app window by stripping the build host's libwayland-client

### DIFF
--- a/scripts/build-tauri.ts
+++ b/scripts/build-tauri.ts
@@ -607,32 +607,41 @@ async function installPatchedGtkPlugin() {
 }
 
 /**
- * Strip the build host's Wayland core libraries from the extracted AppDir.
+ * Strip the build host's libwayland-client from the extracted AppDir.
  *
- * The linuxdeploy build Tauri's bundler uses deploys libwayland-client and
- * libwayland-server from the build host into AppDir/usr/lib. At runtime the
- * AppImage's AppRun wrapper prepends AppDir/usr/lib to LD_LIBRARY_PATH for the
- * whole process tree, so the host's Mesa libEGL — which links both libraries
- * and is correctly NOT bundled, like libGL/libgbm/libdrm — resolves those
- * SONAMEs to the bundled copies instead of the host's own. When the target
- * distro's Mesa was built against a newer libwayland than the build host's
- * (wayland 1.20 on our ubuntu-22.04 CI), symbol resolution fails, no EGL
- * display can be created, and WebKitWebProcess aborts with
- * `Could not create default EGL display: EGL_BAD_PARAMETER` — a blank white
- * window while the backend keeps running (khoj-ai/pipali#21). The canonical
- * AppImage excludelist mandates leaving libwayland-client system-provided:
- * "New version of Mesa has some dependency issues with libwayland-client if
- * it is bundled". Any host that can render the app already ships both libs,
- * because host Mesa's libEGL itself links them.
+ * The linuxdeploy build Tauri's bundler uses deploys libwayland-client from
+ * the build host into AppDir/usr/lib. At runtime the AppImage's AppRun
+ * wrapper prepends AppDir/usr/lib to LD_LIBRARY_PATH for the whole process
+ * tree, so the host's Mesa libEGL — which links libwayland-client and is
+ * correctly NOT bundled, like libGL/libgbm/libdrm — resolves that SONAME to
+ * the bundled copy instead of the host's own. When the target distro's Mesa
+ * was built against a newer libwayland than the build host's (wayland 1.20 on
+ * our ubuntu-22.04 CI), symbol resolution fails (e.g. current Arch/Fedora
+ * Mesa needs wl_fixes_interface, added in wayland 1.24), no EGL display can
+ * be created, and WebKitWebProcess aborts with `Could not create default EGL
+ * display: EGL_BAD_PARAMETER` — a blank white window while the backend keeps
+ * running (khoj-ai/pipali#21). The canonical AppImage excludelist mandates
+ * leaving exactly this library system-provided: "New version of Mesa has some
+ * dependency issues with libwayland-client if it is bundled". Any host that
+ * can render the app already ships it, because host Mesa's libEGL itself
+ * links it (verified on Ubuntu 24.04 / Debian 13 / Fedora and Arch current).
  *
- * libwayland-cursor and libwayland-egl deliberately stay bundled: the bundled
- * libgdk-3 needs them at load time (stripping them would add a new host
- * package requirement), and they only call the wayland client library's
- * stable, additive public ABI, so they work fine against the host's copy.
+ * The other three bundled Wayland libraries deliberately stay bundled:
+ * - libwayland-server: the bundled libwebkit2gtk links it, and current Mesa
+ *   (Arch 26.2 / Fedora 26.1 / Ubuntu 24.04) does NOT link it anymore, so the
+ *   host provides no guarantee it is installed — stripping it makes the app
+ *   fail to start on hosts without it (verified on a minimal Fedora with
+ *   working X11+Mesa). Keeping it is safe: the only host library that may
+ *   bind it (Debian 13's Mesa) uses long-stable wayland-server ABI that the
+ *   bundled 1.20 copy fully exports (symbol-diffed).
+ * - libwayland-cursor / libwayland-egl: the bundled libgdk-3 needs them at
+ *   load time (stripping them would add a new host package requirement), and
+ *   they only call the wayland client library's stable, additive public ABI,
+ *   so they work fine against the host's newer copy.
  */
-const BUILD_HOST_WAYLAND_LIB_PREFIXES = ["libwayland-client.so", "libwayland-server.so"];
+const BUILD_HOST_WAYLAND_LIB_PREFIXES = ["libwayland-client.so"];
 
-async function stripBundledWaylandLibs(extractRoot: string) {
+async function stripBundledWaylandClient(extractRoot: string) {
     const removed: string[] = [];
 
     async function walk(dir: string) {
@@ -656,7 +665,7 @@ async function stripBundledWaylandLibs(extractRoot: string) {
     await walk(path.join(extractRoot, "usr", "lib64"));
 
     if (removed.length === 0) {
-        console.log("   No bundled Wayland core libraries found to strip");
+        console.log("   No bundled libwayland-client found to strip");
     }
     for (const lib of removed) {
         console.log(`   Stripped bundled ${lib} (host provides it, see khoj-ai/pipali#21)`);
@@ -746,7 +755,7 @@ async function repackAppImageWithPristineSidecars(debug: boolean, platform: Plat
         console.log(`   Restored pristine ${name}`);
     }
 
-    await stripBundledWaylandLibs(extractRoot);
+    await stripBundledWaylandClient(extractRoot);
 
     // Without this verify step the build could regress to silently shipping a
     // corrupted bun again — the original symptom only surfaces at app launch.

--- a/scripts/build-tauri.ts
+++ b/scripts/build-tauri.ts
@@ -607,6 +607,63 @@ async function installPatchedGtkPlugin() {
 }
 
 /**
+ * Strip the build host's Wayland core libraries from the extracted AppDir.
+ *
+ * The linuxdeploy build Tauri's bundler uses deploys libwayland-client and
+ * libwayland-server from the build host into AppDir/usr/lib. At runtime the
+ * AppImage's AppRun wrapper prepends AppDir/usr/lib to LD_LIBRARY_PATH for the
+ * whole process tree, so the host's Mesa libEGL — which links both libraries
+ * and is correctly NOT bundled, like libGL/libgbm/libdrm — resolves those
+ * SONAMEs to the bundled copies instead of the host's own. When the target
+ * distro's Mesa was built against a newer libwayland than the build host's
+ * (wayland 1.20 on our ubuntu-22.04 CI), symbol resolution fails, no EGL
+ * display can be created, and WebKitWebProcess aborts with
+ * `Could not create default EGL display: EGL_BAD_PARAMETER` — a blank white
+ * window while the backend keeps running (khoj-ai/pipali#21). The canonical
+ * AppImage excludelist mandates leaving libwayland-client system-provided:
+ * "New version of Mesa has some dependency issues with libwayland-client if
+ * it is bundled". Any host that can render the app already ships both libs,
+ * because host Mesa's libEGL itself links them.
+ *
+ * libwayland-cursor and libwayland-egl deliberately stay bundled: the bundled
+ * libgdk-3 needs them at load time (stripping them would add a new host
+ * package requirement), and they only call the wayland client library's
+ * stable, additive public ABI, so they work fine against the host's copy.
+ */
+const BUILD_HOST_WAYLAND_LIB_PREFIXES = ["libwayland-client.so", "libwayland-server.so"];
+
+async function stripBundledWaylandLibs(extractRoot: string) {
+    const removed: string[] = [];
+
+    async function walk(dir: string) {
+        // Directory may not exist in this AppDir layout (e.g. usr/lib64)
+        const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => null);
+        if (!entries) return;
+        for (const entry of entries) {
+            const entryPath = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                // usr/lib/Pipali holds the app's own resources, never linuxdeploy libs
+                if (entry.name === "Pipali") continue;
+                await walk(entryPath);
+            } else if (BUILD_HOST_WAYLAND_LIB_PREFIXES.some((prefix) => entry.name.startsWith(prefix))) {
+                await fs.rm(entryPath, { force: true });
+                removed.push(path.relative(extractRoot, entryPath));
+            }
+        }
+    }
+
+    await walk(path.join(extractRoot, "usr", "lib"));
+    await walk(path.join(extractRoot, "usr", "lib64"));
+
+    if (removed.length === 0) {
+        console.log("   No bundled Wayland core libraries found to strip");
+    }
+    for (const lib of removed) {
+        console.log(`   Stripped bundled ${lib} (host provides it, see khoj-ai/pipali#21)`);
+    }
+}
+
+/**
  * Repack the produced AppImage with pristine sidecar binaries (bun, uv, uvx).
  *
  * Even with the GTK plugin patch above keeping linuxdeploy from crashing, the
@@ -688,6 +745,8 @@ async function repackAppImageWithPristineSidecars(debug: boolean, platform: Plat
         await fs.chmod(dst, 0o755);
         console.log(`   Restored pristine ${name}`);
     }
+
+    await stripBundledWaylandLibs(extractRoot);
 
     // Without this verify step the build could regress to silently shipping a
     // corrupted bun again — the original symptom only surfaces at app launch.


### PR DESCRIPTION
## Problem

The Linux AppImage opens a blank white window on many distros (notably Arch/Fedora and Intel/AMD graphics) with `Could not create default EGL display: EGL_BAD_PARAMETER` in the console, while the backend keeps running — `http://localhost:6464` works fine in a system browser. Reported in #21. It persists with the #44 WebKit env vars because the failure is below WebKit's renderer selection: EGL cannot create *any* display.

## Root cause

The linuxdeploy build used by Tauri's bundler deploys `libwayland-client.so.0` and `libwayland-server.so.0` from the build host (ubuntu-22.04, wayland 1.20) into the AppImage. Extracting the released 0.7.0 AppImage shows the full chain:

- AppRun exports `LD_LIBRARY_PATH=$APPDIR/usr/lib:...` for the whole process tree, and the bundled `libgdk-3`/`libwebkit2gtk` bind the bundled wayland libs via `$ORIGIN` RUNPATH, so they are in-process from startup.
- `libEGL`/`libGL`/`libgbm`/`libdrm`/Mesa are (correctly) **not** bundled — linuxdeploy's excludelist leaves them to the host. `libwebkit2gtk-4.1.so.0` NEEDs host `libgbm.so.1`/`libdrm.so.2`, and `libgstgl-1.0.so.0` NEEDs host `libEGL.so.1` directly.
- When host Mesa's `libEGL` loads, the dynamic linker resolves its `libwayland-client.so.0`/`libwayland-server.so.0` SONAMEs to the already-loaded, bundled wayland 1.20 copies (the bundled lib exports `wl_display_create_queue` but not `wl_display_create_queue_with_name`, added in wayland 1.22.90).
- On distros whose Mesa was built against a newer libwayland, symbol resolution fails → no EGL display → `WebKitWebProcess` aborts → blank window, healthy backend.

This explains the cross-distro build matrix in #21 (works where the build host's wayland is new enough for the target's Mesa, fails otherwise) and the Intel/AMD-vs-Nvidia asymmetry from the linked tauri-apps/tauri#5143 thread (Nvidia's proprietary EGL doesn't couple to Mesa's libwayland). The canonical [AppImage excludelist](https://github.com/AppImageCommunity/pkg2appimage/blob/master/excludelist) mandates excluding `libwayland-client` for exactly this reason: *"New version of Mesa has some dependency issues with libwayland-client if it is bundled."* The linuxdeploy snapshot Tauri re-hosts doesn't apply that entry, and neither upstream's GTK plugin nor our vendored copy handles it.

## Fix

Strip `libwayland-client.so*` and `libwayland-server.so*` during the existing AppImage repack step (from #43), so the target system's matched wayland ↔ Mesa pair is used at runtime.

- **No new host requirement**: any host able to render the app already provides both — its Mesa `libEGL` literally links them.
- **`libwayland-cursor`/`-egl` deliberately stay bundled**: the bundled `libgdk-3` needs them at load time (stripping them *would* add a new host package requirement), and they only call the wayland client library's stable, additive public ABI, so they work against the host's copy.
- The #43 sidecar restore and its `bun --version` verification are untouched and still run.
- Every stripped library is logged in CI output on every Linux build, so a regression (or linuxdeploy fixing this upstream) is visible.

## Testing

- Extracted and inspected the released `Pipali_0.7.0_amd64.AppImage` (library inventory, ELF `DT_NEEDED`/RUNPATH of `pipali`, `libgdk-3`, `libwebkit2gtk`, `WebKitWebProcess`, `libgstgl`, AppRun env) — evidence chain above.
- Ran the strip function against the real extracted 0.7.0 tree plus decoys: removes exactly the two target libraries in all layouts (`usr/lib`, `usr/lib/x86_64-linux-gnu`, `usr/lib64`, `.so.0.20.0` realname variants); never touches `libwayland-cursor`/`-egl`, GTK/WebKit libraries, sidecars, or app resources under `usr/lib/Pipali`.
- `bunx tsc --noEmit` clean for this change; `bun test` unchanged.
- **Runtime A/B validation on real distro userlands** (see the PR comment below for full details): baseline 0.8.0 AppImage vs the same AppDir with this strip applied, on pristine current Arch, Fedora 44, and Debian 13 userlands (unprivileged sandboxes, Xvfb + llvmpipe) and on real Ubuntu 24.04 hardware. Arch and Fedora reproduce #21 verbatim with the baseline (`Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...`, blank window, healthy backend) and render the app UI with the strip applied. Debian 13 and Ubuntu 24.04 work with both builds (their Mesa's needs are satisfiable either way) — no regression.

## Compatibility considerations

- Verified layers: packaging pipeline, artifact contents, and now runtime behavior on Arch / Fedora 44 / Debian 13 userlands + Ubuntu 24.04 hardware (above).
- Remaining reasoned-only window: hosts lacking `libwayland-client` entirely (custom Mesa built without Wayland) — no mainstream distro ships such a Mesa. Hosts with wayland < 1.20 have glibc too old to load the ubuntu-22.04-built bundle today, so nothing newly breaks there.

## Remaining limitations

The distro-userland runs cover X11 sessions with software rendering; a confirmation from an affected #21 reporter on bare metal (Arch/Fedora, Intel/AMD graphics, Wayland session) would make it definitive — on Arch/Fedora the failure is at `dlopen` time (BIND_NOW), so it is session-independent, but it would be good to see it. Hence still *Addresses*, not *Fixes*. Complements (does not replace) #44, which targets the separate WebKitGTK DMA-BUF renderer failure inside a working EGL stack.

Addresses #21
