### PR TITLE
Enable Pipali to Delegate Background Tasks for Async, Parallel Work

### DIFF
--- a/drizzle/0024_delegated_conversations.sql
+++ b/drizzle/0024_delegated_conversations.sql
@@ -1,0 +1,16 @@
+-- Delegated conversations.
+--
+-- conversation.parent_conversation_id is set when an agent delegated the conversation.
+-- It doubles as the delegated marker (delegated <=> NOT NULL) and is what the hard-stop
+-- cascade queries to find a conversation's children. Left unconstrained, like
+-- conversation.automation_id, so deleting a parent leaves children usable on their own.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'conversation' AND column_name = 'parent_conversation_id') THEN
+        ALTER TABLE "conversation" ADD COLUMN "parent_conversation_id" uuid;
+    END IF;
+END $$;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "conversation_parent_conversation_id_idx" ON "conversation" USING btree ("parent_conversation_id");

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,2188 @@
+{
+  "id": "43c3c34c-7f4e-4421-b2ce-8d94d3e9bab8",
+  "prevId": "aa3123a0-643c-43f7-87db-dd816ddbbf16",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_model_api": {
+      "name": "ai_model_api",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_key_user_id_user_id_fk": {
+          "name": "api_key_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_token_unique": {
+          "name": "api_key_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation": {
+      "name": "automation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "trigger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_executions_per_day": {
+          "name": "max_executions_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_executions_per_hour": {
+          "name": "max_executions_per_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_scheduled_at": {
+          "name": "next_scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automation_user_id_user_id_fk": {
+          "name": "automation_user_id_user_id_fk",
+          "tableFrom": "automation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automation_conversation_id_conversation_id_fk": {
+          "name": "automation_conversation_id_conversation_id_fk",
+          "tableFrom": "automation",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_execution": {
+      "name": "automation_execution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "trigger_data": {
+          "name": "trigger_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trajectory": {
+          "name": "trajectory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automation_execution_automation_id_automation_id_fk": {
+          "name": "automation_execution_automation_id_automation_id_fk",
+          "tableFrom": "automation_execution",
+          "tableTo": "automation",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_model": {
+      "name": "chat_model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "max_prompt_size": {
+          "name": "max_prompt_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenizer": {
+          "name": "tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gemini-2.5-flash'"
+        },
+        "friendly_name": {
+          "name": "friendly_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "chat_model_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google'"
+        },
+        "vision_enabled": {
+          "name": "vision_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_responses_api": {
+          "name": "use_responses_api",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "supports_tool_search": {
+          "name": "supports_tool_search",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_model_api_id": {
+          "name": "ai_model_api_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_cost_per_million": {
+          "name": "input_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_cost_per_million": {
+          "name": "output_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_cost_per_million": {
+          "name": "cache_read_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_write_cost_per_million": {
+          "name": "cache_write_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "chat_model_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_tier": {
+          "name": "cost_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended": {
+          "name": "recommended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_model_ai_model_api_id_ai_model_api_id_fk": {
+          "name": "chat_model_ai_model_api_id_ai_model_api_id_fk",
+          "tableFrom": "chat_model",
+          "tableTo": "ai_model_api",
+          "columnsFrom": [
+            "ai_model_api_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ATIF-v1.4'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent": {
+          "name": "agent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_metrics": {
+          "name": "final_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_model_id": {
+          "name": "chat_model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_parent_conversation_id_idx": {
+          "name": "conversation_parent_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "parent_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_user_id_user_id_fk": {
+          "name": "conversation_user_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_chat_model_id_chat_model_id_fk": {
+          "name": "conversation_chat_model_id_chat_model_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "chat_model",
+          "columnsFrom": [
+            "chat_model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_step": {
+      "name": "conversation_step",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_preview": {
+          "name": "message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step": {
+          "name": "step",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_step_conversation_id_idx": {
+          "name": "conversation_step_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_step_source_idx": {
+          "name": "conversation_step_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_step_conversation_id_conversation_id_fk": {
+          "name": "conversation_step_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_step",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_step_conversation_id_step_id_pk": {
+          "name": "conversation_step_conversation_id_step_id_pk",
+          "columns": [
+            "conversation_id",
+            "step_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_user": {
+      "name": "google_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "azp": {
+          "name": "azp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "google_user_user_id_user_id_fk": {
+          "name": "google_user_user_id_user_id_fk",
+          "tableFrom": "google_user",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_state": {
+      "name": "mcp_oauth_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_server_url": {
+          "name": "authorization_server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_metadata_url": {
+          "name": "resource_metadata_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_url": {
+          "name": "resource_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_information": {
+          "name": "client_information",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_authorization_url": {
+          "name": "last_authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_state_server_id_unique": {
+          "name": "mcp_oauth_state_server_id_unique",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_state_server_id_mcp_server_id_fk": {
+          "name": "mcp_oauth_state_server_id_mcp_server_id_fk",
+          "tableFrom": "mcp_oauth_state",
+          "tableTo": "mcp_server",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server": {
+      "name": "mcp_server",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transport_type": {
+          "name": "transport_type",
+          "type": "mcp_transport_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "mcp_auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "oauth_status": {
+          "name": "oauth_status",
+          "type": "mcp_oauth_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_connected'"
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_mode": {
+          "name": "confirmation_mode",
+          "type": "mcp_confirmation_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'always'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_connected_at": {
+          "name": "last_connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled_tools": {
+          "name": "enabled_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_server_name_unique": {
+          "name": "mcp_server_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_confirmation": {
+      "name": "pending_confirmation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "confirmation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pending_confirmation_execution_id_automation_execution_id_fk": {
+          "name": "pending_confirmation_execution_id_automation_execution_id_fk",
+          "tableFrom": "pending_confirmation",
+          "tableTo": "automation_execution",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_auth": {
+      "name": "platform_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_email": {
+          "name": "platform_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_name": {
+          "name": "platform_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_url": {
+          "name": "platform_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "platform_auth_user_id_user_id_fk": {
+          "name": "platform_auth_user_id_user_id_fk",
+          "tableFrom": "platform_auth",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_settings": {
+      "name": "sandbox_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allowed_write_paths": {
+          "name": "allowed_write_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "denied_write_paths": {
+          "name": "denied_write_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "denied_read_paths": {
+          "name": "denied_read_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_domains": {
+          "name": "allowed_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"*\"]'::jsonb"
+        },
+        "allow_local_binding": {
+          "name": "allow_local_binding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sandbox_settings_user_id_user_id_fk": {
+          "name": "sandbox_settings_user_id_user_id_fk",
+          "tableFrom": "sandbox_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sandbox_settings_user_id_unique": {
+          "name": "sandbox_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subscription_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "renewal_date": {
+          "name": "renewal_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled_trial_at": {
+          "name": "enabled_trial_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_phone_number": {
+          "name": "verified_phone_number",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_email": {
+          "name": "verified_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "account_verification_code": {
+          "name": "account_verification_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_verification_code_expiry": {
+          "name": "account_verification_code_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_uuid_unique": {
+          "name": "user_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_chat_model": {
+      "name": "user_chat_model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_chat_model_user_id_user_id_fk": {
+          "name": "user_chat_model_user_id_user_id_fk",
+          "tableFrom": "user_chat_model",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_chat_model_model_id_chat_model_id_fk": {
+          "name": "user_chat_model_model_id_chat_model_id_fk",
+          "tableFrom": "user_chat_model",
+          "tableTo": "chat_model",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.web_scraper": {
+      "name": "web_scraper",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "web_scraper_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.web_search_provider": {
+      "name": "web_search_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "web_search_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personality": {
+          "name": "personality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tools": {
+          "name": "input_tools",
+          "type": "input_tool[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_modes": {
+          "name": "output_modes",
+          "type": "output_mode[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_by_admin": {
+          "name": "managed_by_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chat_model_id": {
+          "name": "chat_model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "style_color": {
+          "name": "style_color",
+          "type": "style_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'orange'"
+        },
+        "style_icon": {
+          "name": "style_icon",
+          "type": "style_icon",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Lightbulb'"
+        },
+        "privacy_level": {
+          "name": "privacy_level",
+          "type": "privacy_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_creator_id_user_id_fk": {
+          "name": "agents_creator_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_chat_model_id_chat_model_id_fk": {
+          "name": "agents_chat_model_id_chat_model_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "chat_model",
+          "columnsFrom": [
+            "chat_model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_slug_unique": {
+          "name": "agents_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.automation_status": {
+      "name": "automation_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "disabled"
+      ]
+    },
+    "public.chat_model_tier": {
+      "name": "chat_model_tier",
+      "schema": "public",
+      "values": [
+        "flagship",
+        "balanced",
+        "lite"
+      ]
+    },
+    "public.chat_model_type": {
+      "name": "chat_model_type",
+      "schema": "public",
+      "values": [
+        "openai",
+        "anthropic",
+        "google"
+      ]
+    },
+    "public.confirmation_status": {
+      "name": "confirmation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied",
+        "expired"
+      ]
+    },
+    "public.execution_status": {
+      "name": "execution_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "awaiting_confirmation",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.mcp_auth_type": {
+      "name": "mcp_auth_type",
+      "schema": "public",
+      "values": [
+        "none",
+        "bearer",
+        "oauth"
+      ]
+    },
+    "public.mcp_confirmation_mode": {
+      "name": "mcp_confirmation_mode",
+      "schema": "public",
+      "values": [
+        "always",
+        "unsafe_only",
+        "never"
+      ]
+    },
+    "public.mcp_oauth_status": {
+      "name": "mcp_oauth_status",
+      "schema": "public",
+      "values": [
+        "not_connected",
+        "auth_pending",
+        "connected",
+        "auth_required",
+        "error"
+      ]
+    },
+    "public.mcp_transport_type": {
+      "name": "mcp_transport_type",
+      "schema": "public",
+      "values": [
+        "stdio",
+        "http"
+      ]
+    },
+    "public.subscription_type": {
+      "name": "subscription_type",
+      "schema": "public",
+      "values": [
+        "free",
+        "premium"
+      ]
+    },
+    "public.trigger_type": {
+      "name": "trigger_type",
+      "schema": "public",
+      "values": [
+        "cron",
+        "file_watch"
+      ]
+    },
+    "public.web_scraper_type": {
+      "name": "web_scraper_type",
+      "schema": "public",
+      "values": [
+        "exa",
+        "direct",
+        "platform"
+      ]
+    },
+    "public.web_search_provider_type": {
+      "name": "web_search_provider_type",
+      "schema": "public",
+      "values": [
+        "exa",
+        "serper",
+        "platform"
+      ]
+    },
+    "public.input_tool": {
+      "name": "input_tool",
+      "schema": "public",
+      "values": [
+        "general",
+        "online",
+        "notes",
+        "webpage",
+        "code"
+      ]
+    },
+    "public.output_mode": {
+      "name": "output_mode",
+      "schema": "public",
+      "values": [
+        "image",
+        "diagram"
+      ]
+    },
+    "public.privacy_level": {
+      "name": "privacy_level",
+      "schema": "public",
+      "values": [
+        "public",
+        "private",
+        "protected"
+      ]
+    },
+    "public.style_color": {
+      "name": "style_color",
+      "schema": "public",
+      "values": [
+        "blue",
+        "green",
+        "red",
+        "yellow",
+        "orange",
+        "purple",
+        "pink",
+        "teal",
+        "cyan",
+        "lime",
+        "indigo",
+        "fuchsia",
+        "rose",
+        "sky",
+        "amber",
+        "emerald"
+      ]
+    },
+    "public.style_icon": {
+      "name": "style_icon",
+      "schema": "public",
+      "values": [
+        "Lightbulb",
+        "Health",
+        "Robot",
+        "Aperture",
+        "GraduationCap",
+        "Jeep",
+        "Island",
+        "MathOperations",
+        "Asclepius",
+        "Couch",
+        "Code",
+        "Atom",
+        "ClockCounterClockwise",
+        "PencilLine",
+        "Chalkboard",
+        "Cigarette",
+        "CraneTower",
+        "Heart",
+        "Leaf",
+        "NewspaperClipping",
+        "OrangeSlice",
+        "SmileyMelting",
+        "YinYang",
+        "SneakerMove",
+        "Student",
+        "Oven",
+        "Gavel",
+        "Broadcast"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1783723955432,
       "tag": "0023_bitter_squirrel_girl",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1785880754536,
+      "tag": "0024_delegated_conversations",
+      "breakpoints": true
     }
   ]
 }

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -29,6 +29,7 @@ import { useFocusManagement, useFileDrop, useModels, useSidecar, useWebSocketCha
 import { setApiBaseUrl, apiFetch } from "./utils/api";
 import { generateUUID, generateDeterministicId, getToolCategory, type ToolCategory } from "./utils/formatting";
 import { initNotifications, notifyConfirmationRequest, notifyTaskComplete, setNotificationClickHandler, setupNotificationClickListener, warmAudioContext } from "./utils/notifications";
+import { ConversationNavigationContext } from "./hooks/useConversationNavigation";
 import { useVoiceSettings } from "./hooks/useVoiceSettings";
 import { useVoiceCompanion } from "./hooks/useVoiceCompanion";
 import type { VoiceMode } from "./utils/voice/voice-config";
@@ -1152,6 +1153,13 @@ const App = () => {
     // ===== Conversation Actions =====
 
     // Derive active tasks from conversationStates for home page display
+    // Delegated conversations are reached from the step that started them, not the
+    // sidebar. The open one stays listed so navigating into it does not leave the
+    // sidebar showing nothing for where you are.
+    const sidebarConversations = conversations.filter(
+        conv => !conv.parentConversationId || conv.id === conversationId,
+    );
+
     const getActiveTasks = (): ActiveTask[] => {
         const activeTasks: ActiveTask[] = [];
 
@@ -1159,6 +1167,9 @@ const App = () => {
             const hasPendingConfirmation = (pendingConfirmations.get(convId)?.length ?? 0) > 0;
             if (state.isProcessing || state.isStopped || state.isCompleted || hasPendingConfirmation) {
                 const conv = conversations.find(c => c.id === convId);
+                // A delegated task belongs to the conversation that started it, and shows
+                // there as a step. Home lists work the user began.
+                if (conv?.parentConversationId) return;
                 // Get latest user message from conversation messages or title
                 const latestUserMessage = state.messages
                     .filter(m => m.role === 'user')
@@ -1712,11 +1723,12 @@ const App = () => {
     }
 
     return (
+        <ConversationNavigationContext.Provider value={selectConversation}>
         <ErrorBoundary>
             <div className="app-wrapper">
                 <Sidebar
                     isOpen={sidebarOpen}
-                    conversations={conversations}
+                    conversations={sidebarConversations}
                     conversationStates={conversationStates}
                     pendingConfirmations={sidebarPendingConfirmations}
                     currentConversationId={conversationId}
@@ -1871,6 +1883,7 @@ const App = () => {
                 />
             </div>
         </ErrorBoundary>
+        </ConversationNavigationContext.Provider>
     );
 };
 

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -246,10 +246,18 @@ const App = () => {
             notifyConfirmationRequest(request, conv?.title, convId);
             voiceCompanionRef.current?.onConfirmationRequest(request, convId, runId);
         },
+        onRunStarted: (convId) => {
+            // Delegated tasks and routines create their conversation server-side, so a run
+            // on an unknown conversation is the sidebar's first sight of it.
+            if (!conversationsRef.current.some(c => c.id === convId)) fetchConversations();
+        },
         onTaskComplete: (_request, response, convId) => {
             const state = conversationStatesRef.current.get(convId);
             const userRequest = state?.messages.filter(m => m.role === 'user').pop()?.content;
-            notifyTaskComplete(userRequest, response, convId);
+            // A delegated task reports back to the conversation that started it, which
+            // announces itself when it responds. Only that end result is news to the user.
+            const isDelegated = !!conversationsRef.current.find(c => c.id === convId)?.parentConversationId;
+            if (!isDelegated) notifyTaskComplete(userRequest, response, convId);
             voiceCompanionRef.current?.onTaskComplete(response, convId);
             setBillingAlerts([]);
             fetchConversations();

--- a/src/client/components/thoughts/ThoughtItem.tsx
+++ b/src/client/components/thoughts/ThoughtItem.tsx
@@ -1,8 +1,9 @@
 // Individual thought/tool_call rendering
 
 import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { Thought } from '../../types';
-import { formatToolArgs, getFriendlyToolName, formatToolArgsRich, getToolCategory, getDelegatedConversationId } from '../../utils/formatting';
+import { formatDelegationToolResult, formatToolArgs, getFriendlyToolName, formatToolArgsRich, getToolCategory, getDelegatedConversationId } from '../../utils/formatting';
 import { getToolResultStatus } from '../../utils/toolStatus';
 import { useConversationNavigation } from '../../hooks/useConversationNavigation';
 import { ExternalLink } from '../ExternalLink';
@@ -53,6 +54,7 @@ interface ThoughtItemProps {
     showResult?: boolean; // false = outline (title only), true = full (title + result)
     onToggle?: () => void; // Toggle this item's detail level individually
     uidMap?: Map<string, { role: string; label: string }>; // Chrome snapshot uid→label map
+    delegatedTaskTitles?: Map<string, string>;
 }
 
 // Clear markdown markers for the single-line outline view, where the
@@ -62,7 +64,8 @@ function formatPlainText(text: string): string {
     return text.replace(/\*\*([^*]+)\*\*/g, '$1');
 }
 
-export function ThoughtItem({ thought, stepNumber, isPreview = false, showResult = true, onToggle, uidMap }: ThoughtItemProps) {
+export function ThoughtItem({ thought, stepNumber, isPreview = false, showResult = true, onToggle, uidMap, delegatedTaskTitles }: ThoughtItemProps) {
+    const { t } = useTranslation();
     const navigateToConversation = useConversationNavigation();
     // Track whether the reasoning text is overflowing (truncated by ellipsis)
     const [isOverflowing, setIsOverflowing] = useState(false);
@@ -99,10 +102,35 @@ export function ThoughtItem({ thought, stepNumber, isPreview = false, showResult
 
     if (thought.type === 'tool_call') {
         const toolName = thought.toolName || '';
-        const richArgs = formatToolArgsRich(toolName, thought.toolArgs, !showResult, uidMap);
+        const delegationText = {
+            background: t('thoughts.delegationBackground'),
+            modelTier: (tier: string) => {
+                const tierLabels: Record<string, string> = {
+                    flagship: t('inputArea.tierFlagship'),
+                    balanced: t('inputArea.tierBalanced'),
+                    lite: t('inputArea.tierLite'),
+                };
+                return t('thoughts.delegationModel', { tier: tierLabels[tier] ?? tier });
+            },
+            waitForTasks: (tasks: string) => t('thoughts.waitForTasks', { tasks }),
+            noRunInProgress: t('thoughts.noRunInProgress'),
+        };
+        const richArgs = formatToolArgsRich(
+            toolName,
+            thought.toolArgs,
+            !showResult,
+            uidMap,
+            delegatedTaskTitles,
+            delegationText,
+        );
         const formattedArgs = richArgs ? '' : formatToolArgs(toolName, thought.toolArgs);
         const friendlyToolName = getFriendlyToolName(toolName);
         const isInterrupted = thought.toolResult?.trim() === '[interrupted]';
+        const displayToolResult = formatDelegationToolResult(
+            toolName,
+            thought.toolResult,
+            delegationText.noRunInProgress,
+        );
         const category = getToolCategory(toolName);
         const operationType = toolName.includes('__') ? thought.toolArgs?.operation_type : undefined;
 
@@ -226,12 +254,12 @@ export function ThoughtItem({ thought, stepNumber, isPreview = false, showResult
                                 />
                             )}
                             {/* Show regular result for other tools, or error output for tools with suppressed results */}
-                            {!isInterrupted && thought.toolResult && (
+                            {!isInterrupted && displayToolResult && (
                                 !TOOLS_WITH_CUSTOM_VIEWS.has(toolName) ||
                                 (stepStatus === 'error' && !TOOLS_WITH_ERROR_HANDLING_VIEWS.has(toolName))
                             ) && (
                                 <ToolResultView
-                                    result={thought.toolResult}
+                                    result={displayToolResult}
                                     toolName={friendlyToolName}
                                 />
                             )}

--- a/src/client/components/thoughts/ThoughtItem.tsx
+++ b/src/client/components/thoughts/ThoughtItem.tsx
@@ -2,8 +2,9 @@
 
 import { useCallback, useState } from 'react';
 import type { Thought } from '../../types';
-import { formatToolArgs, getFriendlyToolName, formatToolArgsRich, getToolCategory } from '../../utils/formatting';
+import { formatToolArgs, getFriendlyToolName, formatToolArgsRich, getToolCategory, getDelegatedConversationId } from '../../utils/formatting';
 import { getToolResultStatus } from '../../utils/toolStatus';
+import { useConversationNavigation } from '../../hooks/useConversationNavigation';
 import { ExternalLink } from '../ExternalLink';
 import { ChatMarkdown } from '../ChatMarkdown';
 import { ThoughtDiffView } from '../tool-views/ThoughtDiffView';
@@ -62,6 +63,7 @@ function formatPlainText(text: string): string {
 }
 
 export function ThoughtItem({ thought, stepNumber, isPreview = false, showResult = true, onToggle, uidMap }: ThoughtItemProps) {
+    const navigateToConversation = useConversationNavigation();
     // Track whether the reasoning text is overflowing (truncated by ellipsis)
     const [isOverflowing, setIsOverflowing] = useState(false);
     const reasoningRef = useCallback((el: HTMLDivElement | null) => {
@@ -107,6 +109,8 @@ export function ThoughtItem({ thought, stepNumber, isPreview = false, showResult
         // Determine success/error status for step indicator (pending takes precedence)
         const stepStatus = thought.isPending ? 'pending' : getToolResultStatus(thought.toolResult, toolName);
         const canToggle = !!onToggle;
+        // Delegated conversations are kept out of the sidebar, so this step is the way in
+        const delegatedConversationId = getDelegatedConversationId(toolName, thought.toolResult);
 
         return (
             <div className={`thought-item ${isPreview ? 'preview' : ''} ${thought.isPending ? 'pending' : ''}`}>
@@ -128,6 +132,14 @@ export function ThoughtItem({ thought, stepNumber, isPreview = false, showResult
                                     <ExternalLink href={richArgs.url} className="thought-args-link">
                                         {richArgs.text}
                                     </ExternalLink>
+                                ) : delegatedConversationId && navigateToConversation ? (
+                                    <button
+                                        type="button"
+                                        className="thought-args-link thought-args-button"
+                                        onClick={(e) => { e.stopPropagation(); navigateToConversation(delegatedConversationId); }}
+                                    >
+                                        {richArgs.text}
+                                    </button>
                                 ) : (
                                     <span className="thought-args-primary">{richArgs.text}</span>
                                 )}

--- a/src/client/components/thoughts/ThoughtsSection.tsx
+++ b/src/client/components/thoughts/ThoughtsSection.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronDown, ChevronRight, ChevronUp, Globe, FileSearch, Pencil, Terminal, Wrench } from 'lucide-react';
 import type { Thought } from '../../types';
 import { ThoughtItem } from './ThoughtItem';
-import { getToolCategory, type ToolCategory } from '../../utils/formatting';
+import { buildDelegatedTaskTitleMap, getToolCategory, type ToolCategory } from '../../utils/formatting';
 import { parseSnapshotUids } from '../../utils/snapshotParser';
 
 const CATEGORY_ICONS: Record<ToolCategory, React.ComponentType<{ size?: number }>> = {
@@ -126,6 +126,8 @@ export function ThoughtsSection({ thoughts, isStreaming }: ThoughtsSectionProps)
         return map.size > 0 ? map : undefined;
     }, [thoughts]);
 
+    const delegatedTaskTitles = useMemo(() => buildDelegatedTaskTitleMap(thoughts), [thoughts]);
+
     const collapsedPreviewThoughts = useMemo(() => (
         isStreaming && expandLevel === 0
             ? getCollapsedPreviewThoughts(splitMultiHeadingThoughts(thoughts))
@@ -223,6 +225,7 @@ export function ThoughtsSection({ thoughts, isStreaming }: ThoughtsSectionProps)
                                     isPreview={true}
                                     showResult={false}
                                     uidMap={uidMap}
+                                    delegatedTaskTitles={delegatedTaskTitles}
                                 />
                             );
                         })}
@@ -251,6 +254,7 @@ export function ThoughtsSection({ thoughts, isStreaming }: ThoughtsSectionProps)
                                     showResult={showResult}
                                     onToggle={() => toggleItem(thought.id)}
                                     uidMap={uidMap}
+                                    delegatedTaskTitles={delegatedTaskTitles}
                                 />
                             );
                         })}

--- a/src/client/hooks/useConversationNavigation.ts
+++ b/src/client/hooks/useConversationNavigation.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Opens a conversation by id, for anything deep in the tree that names one.
+ *
+ * Delegated conversations are kept out of the sidebar, so a trajectory step that
+ * started one is the way back to it. Threading the callback through every layer
+ * between the app and a tool call would touch components that have no other
+ * interest in it.
+ */
+export const ConversationNavigationContext = createContext<((conversationId: string) => void) | null>(null);
+
+export function useConversationNavigation(): ((conversationId: string) => void) | null {
+    return useContext(ConversationNavigationContext);
+}

--- a/src/client/hooks/useWebSocketChat.ts
+++ b/src/client/hooks/useWebSocketChat.ts
@@ -1367,6 +1367,8 @@ export interface UseWebSocketChatOptions {
     wsUrl: string;
     onConversationCreated?: (conversationId: string, history?: any[]) => void;
     onConfirmationRequest?: (request: ConfirmationRequest, conversationId: string, runId: string) => void;
+    /** Fires for every run, including ones this client never started. */
+    onRunStarted?: (conversationId: string, runId: string) => void;
     onTaskComplete?: (request: string | undefined, response: string, conversationId: string) => void;
     onStepStart?: (conversationId: string, runId: string) => void;
     onBillingError?: (error: BillingError, conversationId?: string) => void;
@@ -1380,6 +1382,7 @@ export function useWebSocketChat(options: UseWebSocketChatOptions) {
         wsUrl,
         onConversationCreated,
         onConfirmationRequest,
+        onRunStarted,
         onTaskComplete,
         onStepStart,
         onBillingError,
@@ -1410,6 +1413,7 @@ export function useWebSocketChat(options: UseWebSocketChatOptions) {
         UseWebSocketChatOptions,
         | 'onConversationCreated'
         | 'onConfirmationRequest'
+        | 'onRunStarted'
         | 'onTaskComplete'
         | 'onStepStart'
         | 'onBillingError'
@@ -1419,6 +1423,7 @@ export function useWebSocketChat(options: UseWebSocketChatOptions) {
     >>({
         onConversationCreated,
         onConfirmationRequest,
+        onRunStarted,
         onTaskComplete,
         onStepStart,
         onBillingError,
@@ -1431,6 +1436,7 @@ export function useWebSocketChat(options: UseWebSocketChatOptions) {
         callbacksRef.current = {
             onConversationCreated,
             onConfirmationRequest,
+            onRunStarted,
             onTaskComplete,
             onStepStart,
             onBillingError,
@@ -1441,6 +1447,7 @@ export function useWebSocketChat(options: UseWebSocketChatOptions) {
     }, [
         onConversationCreated,
         onConfirmationRequest,
+        onRunStarted,
         onTaskComplete,
         onStepStart,
         onBillingError,
@@ -1469,6 +1476,7 @@ export function useWebSocketChat(options: UseWebSocketChatOptions) {
         const {
             onConversationCreated: onConversationCreatedCb,
             onConfirmationRequest: onConfirmationRequestCb,
+            onRunStarted: onRunStartedCb,
             onTaskComplete: onTaskCompleteCb,
             onStepStart: onStepStartCb,
             onBillingError: onBillingErrorCb,
@@ -1500,6 +1508,7 @@ export function useWebSocketChat(options: UseWebSocketChatOptions) {
                     suggestedRunId: message.suggestedRunId,
                 });
                 acquireWakeLock();
+                onRunStartedCb?.(convId, runId);
                 break;
 
             case 'run_stopped':

--- a/src/client/i18n/locales/de.json
+++ b/src/client/i18n/locales/de.json
@@ -86,6 +86,12 @@
         "tierOther": "Sonstige",
         "recommended": "Empfohlen"
     },
+    "thoughts": {
+        "delegationModel": "an das Modell {{tier}}",
+        "delegationBackground": "im Hintergrund",
+        "waitForTasks": "auf {{tasks}}",
+        "noRunInProgress": "Es wurde keine Aufgabe ausgeführt."
+    },
     "home": {
         "greetings": {
             "default": [

--- a/src/client/i18n/locales/en.json
+++ b/src/client/i18n/locales/en.json
@@ -86,6 +86,12 @@
         "tierOther": "Other",
         "recommended": "Recommended"
     },
+    "thoughts": {
+        "delegationModel": "to {{tier}} model",
+        "delegationBackground": "in background",
+        "waitForTasks": "on {{tasks}}",
+        "noRunInProgress": "No run was in progress."
+    },
     "voice": {
         "beta": "Beta",
         "betaHint": "Turning this on adds the voice controls next to the message box.",

--- a/src/client/i18n/locales/fr.json
+++ b/src/client/i18n/locales/fr.json
@@ -86,6 +86,12 @@
         "tierOther": "Autre",
         "recommended": "Recommand\u00e9"
     },
+    "thoughts": {
+        "delegationModel": "au mod\u00e8le {{tier}}",
+        "delegationBackground": "en arri\u00e8re-plan",
+        "waitForTasks": "pour {{tasks}}",
+        "noRunInProgress": "Aucune t\u00e2che n\u2019\u00e9tait en cours."
+    },
     "home": {
         "greetings": {
             "default": [

--- a/src/client/i18n/locales/ja.json
+++ b/src/client/i18n/locales/ja.json
@@ -86,6 +86,12 @@
         "tierOther": "その他",
         "recommended": "おすすめ"
     },
+    "thoughts": {
+        "delegationModel": "{{tier}}モデルに",
+        "delegationBackground": "バックグラウンドで",
+        "waitForTasks": "{{tasks}}を待機",
+        "noRunInProgress": "実行中のタスクはありませんでした。"
+    },
     "home": {
         "greetings": {
             "default": [

--- a/src/client/i18n/locales/zh.json
+++ b/src/client/i18n/locales/zh.json
@@ -86,6 +86,12 @@
         "tierOther": "其他",
         "recommended": "推荐"
     },
+    "thoughts": {
+        "delegationModel": "交给{{tier}}模型",
+        "delegationBackground": "在后台",
+        "waitForTasks": "等待{{tasks}}",
+        "noRunInProgress": "没有正在运行的任务。"
+    },
     "home": {
         "greetings": {
             "default": [

--- a/src/client/styles/components/thoughts.css
+++ b/src/client/styles/components/thoughts.css
@@ -1266,3 +1266,12 @@
     color: var(--color-accent);
     border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
 }
+
+/* Trajectory step that opens a conversation, styled as the links beside it */
+.thought-args-button {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+}

--- a/src/client/types/conversation.ts
+++ b/src/client/types/conversation.ts
@@ -11,6 +11,8 @@ export type ConversationSummary = {
     chatModelId?: number | null;
     isActive?: boolean;
     isAutomation?: boolean;
+    /** Set when this conversation is a task delegated by another conversation. */
+    parentConversationId?: string | null;
     isPinned?: boolean;
     latestReasoning?: string;
     matchSnippet?: string;

--- a/src/client/utils/formatting.ts
+++ b/src/client/utils/formatting.ts
@@ -1,5 +1,6 @@
 // Formatting utilities for tool names, arguments, and display
 
+import { CONVERSATION_HEADER } from '../../shared';
 import { resolveUidLabel } from './snapshotParser';
 
 /** Format bytes to a human-readable file size string. */
@@ -322,6 +323,13 @@ export function formatToolArgsRich(toolName: string, args: any, outline = false,
             };
         }
 
+        case 'delegate_task': {
+            // title is a required argument, so the fallback is for a model that skipped it
+            const text = args.title || args.message?.split('\n')[0];
+            if (!text) return null;
+            return { text, hoverText: args.message };
+        }
+
         case 'generate_image': {
             if (!args.prompt) return null;
             let text = args.prompt;
@@ -451,4 +459,28 @@ export function generateDeterministicId(prefix: string, content: string): string
     }
     // Append string length to get ~43 bit (vs 32) collision resistance
     return `${prefix}-${hash >>> 0}-${content.length}`;
+}
+
+/**
+ * The conversation a delegate_task step started, so the step can link to it.
+ *
+ * A backgrounded task reports back as JSON; one waited on in the foreground comes
+ * back as the same text summary inspect_task produces, led by its conversation id.
+ * That header's pattern comes from the module that writes it, so the two cannot drift.
+ */
+export function getDelegatedConversationId(toolName: string, toolResult?: string): string | undefined {
+    if (toolName !== 'delegate_task' || !toolResult) {
+        return undefined;
+    }
+
+    try {
+        const started = JSON.parse(toolResult) as { conversation_id?: unknown };
+        if (typeof started.conversation_id === 'string') {
+            return started.conversation_id;
+        }
+    } catch {
+        // Not the JSON shape, so it is the text summary below
+    }
+
+    return toolResult.match(CONVERSATION_HEADER)?.[1];
 }

--- a/src/client/utils/formatting.ts
+++ b/src/client/utils/formatting.ts
@@ -60,6 +60,9 @@ export function formatToolArgs(toolName: string, args: any): string {
         case 'search_web':
             return args.query ? `${args.query}` : '';
 
+        case 'delegate_task':
+            return args.title || args.message || '';
+
         default:
             return Object.entries(args)
                 .filter(([k, v]) => v !== undefined && v !== null && v !== '' && k !== 'operation_type')
@@ -117,6 +120,9 @@ export function formatToolCallsForSidebar(toolCalls: any[]): string {
                 break;
             case 'search_web':
                 detail = args.query ? ` ${args.query}` : '';
+                break;
+            case 'delegate_task':
+                detail = args.title ? ` ${args.title}` : '';
                 break;
             case 'generate_image':
                 if (args.prompt) {
@@ -191,6 +197,12 @@ export function getToolCategory(toolName: string): ToolCategory {
             return 'write';
         case 'shell_command':
             return 'execute';
+        case 'delegate_task':
+        case 'stop_task':
+            return 'execute';
+        case 'inspect_task':
+        case 'wait_for_tasks':
+            return 'read';
         default:
             if (toolName.startsWith('chrome') || toolName.startsWith('browser'))
                 return 'web';
@@ -213,6 +225,10 @@ export function getFriendlyToolName(toolName: string): string {
         "search_web": "Search",
         "read_webpage": "Read",
         "generate_image": "Generate",
+        "delegate_task": "Delegate",
+        "inspect_task": "Check",
+        "stop_task": "Stop",
+        "wait_for_tasks": "Wait",
     };
     if (friendlyNames[toolName]) return friendlyNames[toolName];
 

--- a/src/client/utils/formatting.ts
+++ b/src/client/utils/formatting.ts
@@ -247,6 +247,13 @@ export interface RichToolArgs {
     hoverText?: string;
 }
 
+export interface DelegationToolText {
+    background: string;
+    modelTier: (tier: string) => string;
+    waitForTasks: (tasks: string) => string;
+    noRunInProgress: string;
+}
+
 /**
  * Split a path into basename and folder with home dir stripped.
  * Returns [basename, folder] where folder has ~/ prefix removed.
@@ -267,7 +274,14 @@ function splitPath(fullPath: string): [string, string] {
  * File tools return structured primary/secondary text at all detail levels.
  * In outline mode, primary is basename; in full mode, primary includes more context.
  */
-export function formatToolArgsRich(toolName: string, args: any, outline = false, uidMap?: Map<string, { role: string; label: string }>): RichToolArgs | null {
+export function formatToolArgsRich(
+    toolName: string,
+    args: any,
+    outline = false,
+    uidMap?: Map<string, { role: string; label: string }>,
+    delegatedTaskTitles?: Map<string, string>,
+    delegationText?: DelegationToolText,
+): RichToolArgs | null {
     if (!args || typeof args !== 'object') return null;
 
     switch (toolName) {
@@ -327,7 +341,34 @@ export function formatToolArgsRich(toolName: string, args: any, outline = false,
             // title is a required argument, so the fallback is for a model that skipped it
             const text = args.title || args.message?.split('\n')[0];
             if (!text) return null;
-            return { text, hoverText: args.message };
+            const secondary = [
+                typeof args.model_tier === 'string'
+                    ? delegationText?.modelTier(args.model_tier) ?? args.model_tier
+                    : undefined,
+                args.run_in_background !== false ? delegationText?.background : undefined,
+            ].filter(Boolean).join(' ');
+            return { text, secondary: secondary || undefined, hoverText: args.message };
+        }
+        case 'wait_for_tasks': {
+            const ids: string[] = Array.isArray(args.conversation_ids)
+                ? args.conversation_ids.filter((id: unknown): id is string => typeof id === 'string')
+                : [];
+            if (ids.length === 0) return null;
+            const tasks = ids.map(id => delegatedTaskTitles?.get(id) ?? id).join(', ');
+            return {
+                text: delegationText?.waitForTasks(tasks) ?? tasks,
+                hoverText: ids.join(', '),
+            };
+        }
+
+        case 'inspect_task':
+        case 'stop_task': {
+            if (typeof args.conversation_id !== 'string') return null;
+            const title = delegatedTaskTitles?.get(args.conversation_id);
+            return {
+                text: title ?? args.conversation_id,
+                hoverText: args.conversation_id,
+            };
         }
 
         case 'generate_image': {
@@ -483,4 +524,57 @@ export function getDelegatedConversationId(toolName: string, toolResult?: string
     }
 
     return toolResult.match(CONVERSATION_HEADER)?.[1];
+}
+
+/** Match delegated conversation handles in tool results back to their user-facing titles. */
+export function buildDelegatedTaskTitleMap(thoughts: Array<{
+    type: string;
+    toolName?: string;
+    toolArgs?: Record<string, unknown>;
+    toolResult?: string;
+}>): Map<string, string> {
+    const titles = new Map<string, string>();
+    for (const thought of thoughts) {
+        if (thought.type !== 'tool_call' || thought.toolName !== 'delegate_task') continue;
+        const conversationId = getDelegatedConversationId(thought.toolName, thought.toolResult);
+        const title = thought.toolArgs?.title;
+        if (conversationId && typeof title === 'string' && title.trim()) {
+            titles.set(conversationId, title);
+        }
+    }
+    return titles;
+}
+
+/** Remove internal handles and redundant acknowledgements from delegation tool output. */
+export function formatDelegationToolResult(
+    toolName: string,
+    result?: string,
+    noRunInProgress?: string,
+): string | null | undefined {
+    if (!result || !['delegate_task', 'inspect_task', 'wait_for_tasks', 'stop_task'].includes(toolName)) {
+        return result;
+    }
+
+    if (toolName === 'delegate_task') {
+        try {
+            const parsed = JSON.parse(result) as { status?: unknown; conversation_id?: unknown };
+            if (parsed.status === 'started' && typeof parsed.conversation_id === 'string') return null;
+        } catch {
+            // Foreground delegation returns the same readable summary as wait_for_tasks.
+        }
+    }
+
+    if (/^Stopped conversation [0-9a-f-]+\.$/i.test(result)) return null;
+    if (/^Conversation [0-9a-f-]+ had no run in progress\.$/i.test(result)) {
+        return noRunInProgress ?? result;
+    }
+
+    return result
+        .split('\n\n---\n\n')
+        .map(summary => {
+            const [firstLine, ...rest] = summary.split('\n');
+            return firstLine && CONVERSATION_HEADER.test(firstLine) ? rest.join('\n') : summary;
+        })
+        .join('\n\n---\n\n')
+        .trim();
 }

--- a/src/client/utils/toolStatus.ts
+++ b/src/client/utils/toolStatus.ts
@@ -79,5 +79,9 @@ export function getToolResultStatus(toolResult: string | undefined, toolName: st
         return 'error';
     }
 
+    if (toolName && ['delegate_task', 'inspect_task', 'wait_for_tasks', 'stop_task'].includes(toolName)) {
+        return lowerResult.startsWith('error') ? 'error' : 'success';
+    }
+
     return 'neutral';
 }

--- a/src/server/automation/executor/index.ts
+++ b/src/server/automation/executor/index.ts
@@ -11,7 +11,7 @@ import { eq, and, gte, sql } from 'drizzle-orm';
 import { atifConversationService } from '../../processor/conversation/atif/atif.service';
 import type { TriggerEventData } from '../types';
 import type { ConfirmationContext } from '../../processor/confirmation';
-import { createEmptyPreferences } from '../../processor/confirmation';
+import { createEmptyPreferences, CONFIRMATION_TIMEOUT_MS } from '../../processor/confirmation';
 import type { ConfirmationRequest, ConfirmationResponse } from '../../processor/confirmation/confirmation.types';
 import { createStandardConfirmationOptions } from '../../processor/confirmation/confirmation.types';
 import { getOrCreateBus } from '../../events/conversation-event-bus';
@@ -28,7 +28,6 @@ const MAX_RETRIES = 2;
 const RETRY_DELAYS = [15000, 30000]; // 15s, 30s
 
 // Confirmation timeout (24 hours)
-const CONFIRMATION_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 
 // Execution queue (in-memory for MVP)
 interface QueuedExecution {

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -215,10 +215,14 @@ export const Conversation = pgTable('conversation', {
     title: text('title'),
     // Optional link to automation - if set, this conversation belongs to an automation
     automationId: uuid('automation_id'),
+    // Set when an agent delegated this conversation. Doubles as the delegated marker.
+    parentConversationId: uuid('parent_conversation_id'),
     chatModelId: integer('chat_model_id').references(() => ChatModel.id),
     isPinned: boolean('is_pinned').default(false).notNull(),
     ...dbBaseModel,
-});
+}, (table) => [
+    index('conversation_parent_conversation_id_idx').on(table.parentConversationId),
+]);
 
 export const ConversationStep = pgTable('conversation_step', {
     conversationId: uuid('conversation_id').notNull().references(() => Conversation.id, { onDelete: 'cascade' }),

--- a/src/server/events/conversation-event-bus.ts
+++ b/src/server/events/conversation-event-bus.ts
@@ -7,6 +7,7 @@
 
 import type { ServerMessage, QueuedMessage, PendingConfirmation, StopReason } from '../routes/ws/message-types';
 import type { ConfirmationPreferences } from '../processor/confirmation';
+import type { ATIFStep } from '../processor/conversation/atif/atif.types';
 import type { User } from '../db/schema';
 import { createChildLogger } from '../logger';
 
@@ -24,6 +25,11 @@ export interface RunHandle {
     stopReason?: StopReason;
     queuedMessages: QueuedMessage[];
     pendingConfirmations: Map<string, PendingConfirmation>;
+    /**
+     * Steps delivered to this conversation mid-run (e.g. a delegated task finishing).
+     * Already persisted; queued here so the running loop can pick them up.
+     */
+    injectedSteps: ATIFStep[];
 }
 
 export function createRunHandle(runId: string, clientMessageId: string, conversationId: string): RunHandle {
@@ -36,6 +42,7 @@ export function createRunHandle(runId: string, clientMessageId: string, conversa
         stopReason: undefined,
         queuedMessages: [],
         pendingConfirmations: new Map(),
+        injectedSteps: [],
     };
 }
 

--- a/src/server/events/conversation-runs.ts
+++ b/src/server/events/conversation-runs.ts
@@ -1,0 +1,218 @@
+/**
+ * Conversation Run Helpers
+ *
+ * Shared start/stop paths for conversation runs, so the WebSocket commands and the
+ * agent's delegation tools reuse the same run tooling.
+ */
+
+import { eq } from 'drizzle-orm';
+import { db, getChatModelById, getDefaultChatModel } from '../db';
+import { Conversation, User } from '../db/schema';
+import type { ChatModelWithApi } from '../db/schema';
+import { atifConversationService } from '../processor/conversation/atif/atif.service';
+import { createEmptyPreferences, type ConfirmationPreferences } from '../processor/confirmation';
+import { rejectAllConfirmations } from '../routes/ws/confirmation-manager';
+import type { QueuedMessage } from '../routes/ws/message-types';
+import { setSessionInactive } from '../sessions/activeSessionsStore';
+import {
+    getBus,
+    getOrCreateBus,
+    type ConversationEvent,
+    type ConversationEventBus,
+} from './conversation-event-bus';
+import { executeRun } from './run-executor';
+import { createChildLogger } from '../logger';
+
+const log = createChildLogger({ component: 'conversation-runs' });
+
+/**
+ * Resolve which chat model a run should use, persisting the choice on the conversation.
+ *
+ * An explicit `chatModelId` wins; otherwise the conversation's own model, then the user
+ * default. The resolved model is backfilled onto the conversation row so later runs and
+ * the model picker agree.
+ */
+export async function resolveChatModelForRun(
+    user: typeof User.$inferSelect,
+    conversationId?: string,
+    chatModelId?: number,
+): Promise<ChatModelWithApi | undefined> {
+    if (chatModelId !== undefined) {
+        const selected = await getChatModelById(chatModelId);
+        if (!selected) return undefined;
+        if (conversationId) {
+            await db.update(Conversation).set({ chatModelId }).where(eq(Conversation.id, conversationId));
+        }
+        return selected;
+    }
+
+    let resolved: ChatModelWithApi | undefined;
+    if (conversationId) {
+        const [conversation] = await db.select().from(Conversation).where(eq(Conversation.id, conversationId));
+        resolved = conversation?.chatModelId
+            ? await getChatModelById(conversation.chatModelId) ?? await getDefaultChatModel(user)
+            : await getDefaultChatModel(user);
+
+        if (conversation && !conversation.chatModelId && resolved) {
+            await db.update(Conversation)
+                .set({ chatModelId: resolved.chatModel.id })
+                .where(eq(Conversation.id, conversationId));
+        }
+    } else {
+        resolved = await getDefaultChatModel(user);
+    }
+    return resolved;
+}
+
+/**
+ * Queue a message onto a conversation's in-flight run as a soft interrupt.
+ * Returns false when there is no active run, meaning the caller should start one.
+ */
+export function queueMessageOnActiveRun(conversationId: string, queued: QueuedMessage): boolean {
+    const bus = getBus(conversationId);
+    if (!bus?.activeRun) return false;
+
+    const runHandle = bus.activeRun;
+    runHandle.queuedMessages.push(queued);
+    runHandle.stopMode = 'soft';
+    runHandle.stopReason = 'soft_interrupt';
+
+    // A run blocked on a confirmation can't reach the soft-interrupt checkpoint,
+    // so unblock it hard and let the queued message start the next run.
+    if (runHandle.pendingConfirmations.size > 0) {
+        runHandle.stopMode = 'hard';
+        runHandle.abortController.abort();
+        rejectAllConfirmations(runHandle, 'Research interrupted');
+    }
+
+    return true;
+}
+
+export interface StartConversationRunOptions {
+    user: typeof User.$inferSelect;
+    /**
+     * Omit to continue an existing conversation from what is already in its history —
+     * used when waking a conversation after an update was appended to it.
+     */
+    message?: string;
+    /** Omit to create a new conversation. */
+    conversationId?: string;
+    chatModelId?: number;
+    /** Title for a newly created conversation. */
+    title?: string;
+    /** Marks a new conversation as delegated from this parent. */
+    parentConversationId?: string;
+    confirmationPreferences?: ConfirmationPreferences;
+    /** Subscribed to the bus before the run starts, so no events are missed. */
+    onEvent?: (event: ConversationEvent) => void;
+}
+
+export interface StartConversationRunResult {
+    conversationId: string;
+    runId: string;
+    /** True when an in-flight run was soft-interrupted instead of a new run starting. */
+    queued: boolean;
+}
+
+/**
+ * Start a run on a conversation, creating it first when no id is given.
+ *
+ * If the target is already running, the message is queued as a soft interrupt and the
+ * existing run chains into it — the same semantics as sending from the UI mid-run.
+ */
+export async function startConversationRun(
+    options: StartConversationRunOptions,
+): Promise<StartConversationRunResult> {
+    const { user, message, title, parentConversationId, onEvent } = options;
+    const runId = crypto.randomUUID();
+    const clientMessageId = crypto.randomUUID();
+
+    let conversationId = options.conversationId;
+    const chatModelWithApi = await resolveChatModelForRun(user, conversationId, options.chatModelId);
+
+    if (!conversationId) {
+        const created = await atifConversationService.createConversation(
+            user,
+            'pipali-agent',
+            '1.0.0',
+            chatModelWithApi?.chatModel.name ?? 'unknown',
+            title,
+            chatModelWithApi?.chatModel.id,
+        );
+        conversationId = created.id;
+
+        if (parentConversationId) {
+            await db.update(Conversation)
+                .set({ parentConversationId })
+                .where(eq(Conversation.id, conversationId));
+        }
+    }
+
+    if (message && queueMessageOnActiveRun(conversationId, { runId, clientMessageId, message, chatModelId: chatModelWithApi?.chatModel.id })) {
+        log.info({ conversationId, runId }, 'Queued message on active run');
+        return { conversationId, runId, queued: true };
+    }
+
+    const bus = getOrCreateBus(conversationId);
+    bus.user = user;
+    bus.confirmationPreferences = options.confirmationPreferences ?? createEmptyPreferences();
+    bus.chatModelId = chatModelWithApi?.chatModel.id;
+
+    if (onEvent) bus.subscribe(onEvent);
+
+    // Fire and forget: the run outlives this call and reports through the bus.
+    void executeRun({
+        bus,
+        conversationId,
+        user,
+        userMessage: message,
+        runId,
+        clientMessageId,
+        confirmationPreferences: bus.confirmationPreferences,
+        chatModelId: chatModelWithApi?.chatModel.id,
+    }).catch(error => {
+        log.error({ err: error, conversationId, runId }, 'Run failed');
+    });
+
+    return { conversationId, runId, queued: false };
+}
+
+/**
+ * Hard stop a conversation's run: abort it, drop queued messages, reject confirmations.
+ * Idempotent - the run executor calls the same teardown when it catches the abort.
+ */
+export function stopConversationRun(conversationId: string, reason: 'user_stop' = 'user_stop'): boolean {
+    const bus: ConversationEventBus | undefined = getBus(conversationId);
+    if (!bus?.activeRun) return false;
+
+    const runHandle = bus.activeRun;
+    runHandle.stopMode = 'hard';
+    runHandle.stopReason = reason;
+    runHandle.queuedMessages = [];
+    runHandle.abortController.abort();
+    rejectAllConfirmations(runHandle, 'Research stopped');
+
+    // Mark inactive immediately so a refresh/observe sees no active run.
+    setSessionInactive(conversationId);
+    bus.activeRun = null;
+    return true;
+}
+
+/**
+ * Hard stop every delegated child of a conversation that is still running.
+ *
+ * Driven from the DB rather than run-scoped state so children spawned during an
+ * earlier run are still reachable. Returns the ids actually stopped.
+ */
+export async function stopDelegatedChildren(parentConversationId: string): Promise<string[]> {
+    const children = await db
+        .select({ id: Conversation.id })
+        .from(Conversation)
+        .where(eq(Conversation.parentConversationId, parentConversationId));
+
+    const stopped: string[] = [];
+    for (const child of children) {
+        if (stopConversationRun(child.id)) stopped.push(child.id);
+    }
+    return stopped;
+}

--- a/src/server/events/conversation-runs.ts
+++ b/src/server/events/conversation-runs.ts
@@ -98,6 +98,8 @@ export interface StartConversationRunOptions {
     /** Omit to create a new conversation. */
     conversationId?: string;
     chatModelId?: number;
+    /** Row-less platform alias used for this run without persisting a fake model row. */
+    chatModelAlias?: string;
     /** Title for a newly created conversation. */
     title?: string;
     /** Marks a new conversation as delegated from this parent. */
@@ -148,7 +150,13 @@ export async function startConversationRun(
         }
     }
 
-    if (message && queueMessageOnActiveRun(conversationId, { runId, clientMessageId, message, chatModelId: chatModelWithApi?.chatModel.id })) {
+    if (message && queueMessageOnActiveRun(conversationId, {
+        runId,
+        clientMessageId,
+        message,
+        chatModelId: chatModelWithApi?.chatModel.id,
+        chatModelAlias: options.chatModelAlias,
+    })) {
         log.info({ conversationId, runId }, 'Queued message on active run');
         return { conversationId, runId, queued: true };
     }
@@ -170,6 +178,7 @@ export async function startConversationRun(
         clientMessageId,
         confirmationPreferences: bus.confirmationPreferences,
         chatModelId: chatModelWithApi?.chatModel.id,
+        chatModelAlias: options.chatModelAlias,
     }).catch(error => {
         log.error({ err: error, conversationId, runId }, 'Run failed');
     });

--- a/src/server/events/parent-inbox.ts
+++ b/src/server/events/parent-inbox.ts
@@ -1,0 +1,172 @@
+/**
+ * Parent Inbox
+ *
+ * Delivers the result of a long-running operation back into the conversation that
+ * started it. Delegated conversations are the first consumer; a backgrounded command
+ * tool would use the same entry point.
+ *
+ * Updates arrive as `system` steps. Those reach the model inline (see
+ * generateChatmlMessagesWithContext) but are invisible to the conversation preview,
+ * search, and the client's message list — so nothing needs to filter them out.
+ */
+
+import { atifConversationService } from '../processor/conversation/atif/atif.service';
+import type { User } from '../db/schema';
+import { getBus } from './conversation-event-bus';
+import { startConversationRun } from './conversation-runs';
+import { createChildLogger } from '../logger';
+
+const log = createChildLogger({ component: 'parent-inbox' });
+
+/**
+ * Several tasks finishing together should wake the parent once, not once each.
+ */
+const COALESCE_MS = 1_000;
+
+/**
+ * `maxIterations` bounds a single run, not a chain of them: the parent could wake,
+ * delegate, get a completion, wake again, forever. Depth is reset by any real user
+ * message, so this only limits unattended chains.
+ */
+const MAX_AUTO_START_DEPTH = 3;
+
+const autoStartDepth = new Map<string, number>();
+const pendingWakeups = new Map<string, ReturnType<typeof setTimeout>>();
+const suppressed = new Map<string, number>();
+const stoppedByUser = new Set<string>();
+
+/**
+ * Called when the user hard stops a conversation. Stopping cascades to delegated tasks,
+ * and each one reports back that it did not finish — which would otherwise wake the
+ * conversation to narrate the stop the user just asked for.
+ */
+export function suspendAutoStart(conversationId: string): void {
+    stoppedByUser.add(conversationId);
+}
+
+/** Called when the user sends a message, which makes the conversation attended again. */
+export function resumeAutoStart(conversationId: string): void {
+    autoStartDepth.delete(conversationId);
+    stoppedByUser.delete(conversationId);
+}
+
+/**
+ * Stop delivering updates to a conversation while its agent is explicitly waiting on
+ * them. The waiting tool hands the results to the model itself, so appending them again
+ * and waking the conversation afterwards would duplicate the work.
+ *
+ * Returns a release function; always call it in a finally.
+ */
+export function suppressDeliveries(conversationId: string): () => void {
+    suppressed.set(conversationId, (suppressed.get(conversationId) ?? 0) + 1);
+    let released = false;
+    return () => {
+        if (released) return;
+        released = true;
+        const next = (suppressed.get(conversationId) ?? 1) - 1;
+        if (next <= 0) suppressed.delete(conversationId);
+        else suppressed.set(conversationId, next);
+    };
+}
+
+export interface DeliverToParentOptions {
+    parentConversationId: string;
+    user: typeof User.$inferSelect;
+    /** Written verbatim as a system step, so make it self-contained. */
+    message: string;
+}
+
+/**
+ * Append an update to a conversation and make sure the agent acts on it.
+ *
+ * If a run is in flight the update joins it; otherwise the conversation is woken so
+ * the user hears about the result without having to ask.
+ */
+export async function deliverToParent(options: DeliverToParentOptions): Promise<void> {
+    const { parentConversationId, user, message } = options;
+
+    if (suppressed.has(parentConversationId)) {
+        log.debug({ parentConversationId }, 'Delivery suppressed - the agent is waiting on this itself');
+        return;
+    }
+
+    const step = await atifConversationService.addStep(
+        parentConversationId,
+        'system',
+        message,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { kind: 'delegated_task_update' },
+    );
+
+    const bus = getBus(parentConversationId);
+    if (bus?.activeRun) {
+        bus.activeRun.injectedSteps.push(step);
+
+        // The in-flight run may already be past the point where it would notice, so
+        // wake the conversation once the run settles. Terminal errors are left alone —
+        // re-running would just hit the same wall.
+        const unsubscribe = bus.subscribe(event => {
+            if (event.type === 'run_complete' || event.type === 'run_stopped') {
+                unsubscribe();
+                scheduleWakeup(parentConversationId, user);
+            } else if (event.type === 'billing_error' || event.type === 'auth_error') {
+                unsubscribe();
+            }
+        });
+        return;
+    }
+
+    scheduleWakeup(parentConversationId, user);
+}
+
+function scheduleWakeup(conversationId: string, user: typeof User.$inferSelect): void {
+    if (pendingWakeups.has(conversationId)) return;
+
+    const timer = setTimeout(() => {
+        pendingWakeups.delete(conversationId);
+        void wake(conversationId, user);
+    }, COALESCE_MS);
+
+    pendingWakeups.set(conversationId, timer);
+}
+
+async function wake(conversationId: string, user: typeof User.$inferSelect): Promise<void> {
+    if (getBus(conversationId)?.activeRun) {
+        // Something started in the meantime; it will read the update from history.
+        return;
+    }
+
+    if (stoppedByUser.has(conversationId)) {
+        // The update stays in history for the user's next message; it just may not
+        // start a turn on its own. Stop has to mean stop.
+        log.info({ conversationId }, 'Not waking a conversation the user stopped');
+        return;
+    }
+
+    const depth = (autoStartDepth.get(conversationId) ?? 0) + 1;
+    if (depth > MAX_AUTO_START_DEPTH) {
+        log.warn({ conversationId, depth }, 'Auto-start depth exceeded, waiting for the user');
+        return;
+    }
+    autoStartDepth.set(conversationId, depth);
+
+    try {
+        // No user message: the run continues from the update already in history.
+        await startConversationRun({ conversationId, user });
+        log.info({ conversationId, depth }, 'Woke conversation after delegated update');
+    } catch (error) {
+        log.error({ err: error, conversationId }, 'Failed to wake conversation');
+    }
+}
+
+/** For tests: drop pending timers and depth counters. */
+export function clearInboxState(): void {
+    for (const timer of pendingWakeups.values()) clearTimeout(timer);
+    pendingWakeups.clear();
+    autoStartDepth.clear();
+    stoppedByUser.clear();
+}

--- a/src/server/events/run-executor.ts
+++ b/src/server/events/run-executor.ts
@@ -32,6 +32,7 @@ export interface ExecuteRunOptions {
     clientMessageId: string;
     confirmationPreferences: ConfirmationPreferences;
     chatModelId?: number;
+    chatModelAlias?: string;
     /** Override the confirmation context (e.g., for automation hybrid confirmations) */
     confirmationContextOverride?: ConfirmationContext;
 }
@@ -53,6 +54,14 @@ function sanitizeErrorForClient(error: unknown): string {
 
 function isNonEmptyString(value: unknown): value is string {
     return typeof value === 'string' && value.trim().length > 0;
+}
+
+/** A model alias belongs to one queued run; omitting it explicitly returns to the concrete model. */
+function resolveQueuedModel(
+    currentChatModelId: number | undefined,
+    next: Pick<QueuedMessage, 'chatModelId' | 'chatModelAlias'>,
+): [chatModelId: number | undefined, chatModelAlias: string | undefined] {
+    return [next.chatModelId ?? currentChatModelId, next.chatModelAlias];
 }
 
 function ensureUniqueRunId(
@@ -133,6 +142,7 @@ export async function executeRun(options: ExecuteRunOptions): Promise<void> {
     let runId = options.runId;
     let clientMessageId = options.clientMessageId;
     let currentChatModelId = options.chatModelId;
+    let currentChatModelAlias = options.chatModelAlias;
     let carryOverQueue: QueuedMessage[] = [];
 
     while (true) {
@@ -204,6 +214,7 @@ export async function executeRun(options: ExecuteRunOptions): Promise<void> {
                 confirmationContext,
                 systemPrompt: systemPromptOverride,
                 chatModelId: currentChatModelId,
+                chatModelAlias: currentChatModelAlias,
                 conversationRole,
                 runId: runIdAuthoritative,
                 onTextDelta: (delta) => {
@@ -294,7 +305,7 @@ export async function executeRun(options: ExecuteRunOptions): Promise<void> {
                     runId = next.runId;
                     clientMessageId = next.clientMessageId;
                     userMessage = next.message;
-                    currentChatModelId = next.chatModelId ?? currentChatModelId;
+                    [currentChatModelId, currentChatModelAlias] = resolveQueuedModel(currentChatModelId, next);
                     carryOverQueue = rest;
                     continue;
                 }
@@ -331,7 +342,7 @@ export async function executeRun(options: ExecuteRunOptions): Promise<void> {
                     runId = next.runId;
                     clientMessageId = next.clientMessageId;
                     userMessage = next.message;
-                    currentChatModelId = next.chatModelId ?? currentChatModelId;
+                    [currentChatModelId, currentChatModelAlias] = resolveQueuedModel(currentChatModelId, next);
                     carryOverQueue = rest;
                     continue;
                 }
@@ -387,7 +398,7 @@ export async function executeRun(options: ExecuteRunOptions): Promise<void> {
                         runId = next.runId;
                         clientMessageId = next.clientMessageId;
                         userMessage = next.message;
-                        currentChatModelId = next.chatModelId ?? currentChatModelId;
+                        [currentChatModelId, currentChatModelAlias] = resolveQueuedModel(currentChatModelId, next);
                         carryOverQueue = rest;
                         continue;
                     }

--- a/src/server/events/run-executor.ts
+++ b/src/server/events/run-executor.ts
@@ -12,7 +12,7 @@ import { type ConversationEventBus, type RunHandle, createRunHandle } from './co
 import { runResearchWithConversation, ResearchPausedError } from '../processor/research-runner';
 import { PlatformBillingError } from '../http/billing-errors';
 import { PlatformAuthError } from '../http/platform-fetch';
-import { atifConversationService } from '../processor/conversation/atif/atif.service';
+import { atifConversationService, type ConversationRole } from '../processor/conversation/atif/atif.service';
 import { buildSystemPrompt } from '../processor/director';
 import { loadUserContext } from '../user-context';
 import { isFirstRunEasterEgg, maxIterations as defaultMaxIterations } from '../utils';
@@ -168,6 +168,12 @@ export async function executeRun(options: ExecuteRunOptions): Promise<void> {
 
         setSessionActive(conversationId);
 
+        // Resolved per run rather than once, so a conversation that becomes Home or a
+        // delegated task picks up the right framing on its next run.
+        const conversationRole = await atifConversationService
+            .getConversationRole(conversationId, user)
+            .catch(() => 'manual' as ConversationRole);
+
         let systemPromptOverride: string | undefined;
         try {
             systemPromptOverride = await ensureSystemPromptPersisted(conversationId, user.id, userMessage);
@@ -198,6 +204,7 @@ export async function executeRun(options: ExecuteRunOptions): Promise<void> {
                 confirmationContext,
                 systemPrompt: systemPromptOverride,
                 chatModelId: currentChatModelId,
+                conversationRole,
                 runId: runIdAuthoritative,
                 onTextDelta: (delta) => {
                     bus.publish({

--- a/src/server/processor/actor/delegate_task.ts
+++ b/src/server/processor/actor/delegate_task.ts
@@ -7,7 +7,7 @@
  */
 
 import { eq, inArray } from 'drizzle-orm';
-import { db } from '../../db';
+import { db, getChatModelById, getDefaultChatModel } from '../../db';
 import { Conversation, User } from '../../db/schema';
 import { getBus, type ConversationEvent } from '../../events/conversation-event-bus';
 import { startConversationRun, stopConversationRun } from '../../events/conversation-runs';
@@ -17,12 +17,18 @@ import { atifConversationService } from '../conversation/atif/atif.service';
 import type { ATIFStep } from '../conversation/atif/atif.types';
 import type { ConfirmationPreferences } from '../confirmation';
 import { createChildLogger } from '../../logger';
+import {
+    PLATFORM_TIER_MODELS,
+    type PlatformModelTier,
+} from '../conversation';
 
 const log = createChildLogger({ component: 'delegate_task' });
 
 export interface DelegateTaskArgs {
     title: string;
     message: string;
+    /** Omit to use the parent conversation's intelligence tier. */
+    model_tier?: PlatformModelTier;
     /** Omit to start a new task; provide to send a follow-up to one already running. */
     conversation_id?: string;
     /** Default true. When false, the call waits and returns the task's result. */
@@ -47,6 +53,14 @@ export interface WaitForTasksArgs {
 
 export interface DelegationResult {
     compiled: string;
+}
+
+export function selectDelegatedModelAlias(
+    requestedTier: PlatformModelTier | undefined,
+    parentTier: PlatformModelTier | null | undefined,
+): string | undefined {
+    const tier = requestedTier ?? parentTier;
+    return tier ? PLATFORM_TIER_MODELS[tier] : undefined;
 }
 
 function errorResult(message: string): DelegationResult {
@@ -141,6 +155,7 @@ export async function delegateTask(
         parentConversationId?: string;
         confirmationPreferences?: ConfirmationPreferences;
         abortSignal?: AbortSignal;
+        parentChatModelId?: number;
     },
 ): Promise<DelegationResult> {
     const { user, parentConversationId } = options;
@@ -155,12 +170,21 @@ export async function delegateTask(
     }
 
     try {
+        const parentModel = options.parentChatModelId !== undefined
+            ? await getChatModelById(options.parentChatModelId)
+            : await getDefaultChatModel(user);
+        const chatModelAlias = parentModel?.aiModelApi?.name === 'Pipali'
+            ? selectDelegatedModelAlias(args.model_tier, parentModel.chatModel.tier)
+            : undefined;
+
         const result = await startConversationRun({
             user,
             message: args.message,
             conversationId: targetId,
             title: args.title,
             parentConversationId,
+            chatModelId: parentModel?.chatModel.id,
+            chatModelAlias,
             // Inherit as a copy: what the user already approved carries over, but the
             // child saying "don't ask again" must not rewrite the parent's policy.
             confirmationPreferences: options.confirmationPreferences

--- a/src/server/processor/actor/delegate_task.ts
+++ b/src/server/processor/actor/delegate_task.ts
@@ -16,6 +16,7 @@ import { getActiveStatus } from '../../sessions/activeSessionsStore';
 import { atifConversationService } from '../conversation/atif/atif.service';
 import type { ATIFStep } from '../conversation/atif/atif.types';
 import type { ConfirmationPreferences } from '../confirmation';
+import { formatConversationHeader } from '../../../shared';
 import { createChildLogger } from '../../logger';
 import {
     PLATFORM_TIER_MODELS,
@@ -302,7 +303,7 @@ export async function inspectTask(
     const steps = conversation.trajectory.steps.filter(step => step.source !== 'system');
     const status = describeStatus(args.conversation_id);
     const header = [
-        `Conversation: ${args.conversation_id}`,
+        formatConversationHeader(args.conversation_id),
         `Title: ${conversation.title ?? '(untitled)'}`,
         `Status: ${status}`,
     ];

--- a/src/server/processor/actor/delegate_task.ts
+++ b/src/server/processor/actor/delegate_task.ts
@@ -1,0 +1,452 @@
+/**
+ * Delegation tools.
+ *
+ * A delegated task is a normal conversation marked with a parent, run asynchronously
+ * through the same executor as any other conversation. The child conversation id is
+ * the handle: it survives restarts and resolves the live run via the event bus.
+ */
+
+import { eq, inArray } from 'drizzle-orm';
+import { db } from '../../db';
+import { Conversation, User } from '../../db/schema';
+import { getBus, type ConversationEvent } from '../../events/conversation-event-bus';
+import { startConversationRun, stopConversationRun } from '../../events/conversation-runs';
+import { deliverToParent, suppressDeliveries } from '../../events/parent-inbox';
+import { getActiveStatus } from '../../sessions/activeSessionsStore';
+import { atifConversationService } from '../conversation/atif/atif.service';
+import type { ATIFStep } from '../conversation/atif/atif.types';
+import type { ConfirmationPreferences } from '../confirmation';
+import { createChildLogger } from '../../logger';
+
+const log = createChildLogger({ component: 'delegate_task' });
+
+export interface DelegateTaskArgs {
+    title: string;
+    message: string;
+    /** Omit to start a new task; provide to send a follow-up to one already running. */
+    conversation_id?: string;
+    /** Default true. When false, the call waits and returns the task's result. */
+    run_in_background?: boolean;
+    /** Only meaningful when run_in_background is false. */
+    timeout_seconds?: number;
+}
+
+export interface InspectTaskArgs {
+    conversation_id: string;
+    detail?: 'latest' | 'outline' | 'full';
+}
+
+export interface StopTaskArgs {
+    conversation_id: string;
+}
+
+export interface WaitForTasksArgs {
+    conversation_ids: string[];
+    timeout_seconds?: number;
+}
+
+export interface DelegationResult {
+    compiled: string;
+}
+
+function errorResult(message: string): DelegationResult {
+    return { compiled: `Error: ${message}` };
+}
+
+/**
+ * Identifying detail for a tool call, never its payload.
+ *
+ * Mirrors the client's collapsed trajectory view (formatToolCallsForSidebar): a file
+ * name rather than file content, a justification rather than a shell script. Unknown
+ * and MCP tools fall through to name-only so their unbounded arguments can't leak in.
+ */
+const MAX_ARG_CHARS = 200;
+
+export function summarizeToolCall(functionName: string, args: Record<string, unknown>): string {
+    const pick = (key: string): string | undefined => {
+        const value = args?.[key];
+        if (typeof value !== 'string' || !value.trim()) return undefined;
+        return value.length > MAX_ARG_CHARS ? `${value.slice(0, MAX_ARG_CHARS)}…` : value;
+    };
+
+    let detail: string | undefined;
+    switch (functionName) {
+        case 'view_file':
+        case 'read_file':
+        case 'list_files':
+            detail = pick('path');
+            break;
+        case 'edit_file':
+        case 'write_file':
+            detail = pick('file_path');
+            break;
+        case 'grep_files':
+            detail = pick('pattern');
+            break;
+        case 'shell_command':
+            detail = pick('justification');
+            break;
+        case 'search_web':
+            detail = pick('query');
+            break;
+        case 'read_webpage':
+            detail = pick('url');
+            break;
+        case 'generate_image':
+            detail = pick('prompt');
+            break;
+        case 'delegate_task':
+        case 'inspect_task':
+        case 'stop_task':
+        case 'wait_for_tasks':
+            detail = pick('title') ?? pick('conversation_id');
+            break;
+    }
+
+    return detail ? `${functionName}(${detail})` : functionName;
+}
+
+function describeStep(step: ATIFStep): string {
+    const parts: string[] = [];
+    if (step.message) parts.push(`Message: ${step.message}`);
+    const toolCalls = step.tool_calls ?? [];
+    if (toolCalls.length > 0) {
+        const summarized = toolCalls.map(tc => summarizeToolCall(tc.function_name, tc.arguments ?? {}));
+        parts.push(`Tools: ${summarized.join(', ')}`);
+    }
+    return parts.join('\n');
+}
+
+function describeStatus(conversationId: string): string {
+    const status = getActiveStatus(conversationId);
+    if (!status?.isActive) return 'completed or idle';
+    const bus = getBus(conversationId);
+    if ((bus?.activeRun?.pendingConfirmations.size ?? 0) > 0) {
+        return 'running, waiting on user confirmation';
+    }
+    return 'running';
+}
+
+/**
+ * Start a task, or send a follow-up to one already running.
+ *
+ * In the background (the default) this returns once the run is under way and the result
+ * arrives later as a message in the parent. In the foreground it waits and returns the
+ * result itself.
+ */
+export async function delegateTask(
+    args: DelegateTaskArgs,
+    options: {
+        user?: typeof User.$inferSelect;
+        parentConversationId?: string;
+        confirmationPreferences?: ConfirmationPreferences;
+        abortSignal?: AbortSignal;
+    },
+): Promise<DelegationResult> {
+    const { user, parentConversationId } = options;
+    if (!user) return errorResult('Cannot delegate - no user context available');
+    if (!parentConversationId) return errorResult('Cannot delegate - no parent conversation');
+    if (!args?.message?.trim()) return errorResult('message is required');
+
+    const targetId = args.conversation_id;
+    if (targetId) {
+        const [existing] = await db.select().from(Conversation).where(eq(Conversation.id, targetId));
+        if (!existing || existing.userId !== user.id) return errorResult(`Conversation ${targetId} not found`);
+    }
+
+    try {
+        const result = await startConversationRun({
+            user,
+            message: args.message,
+            conversationId: targetId,
+            title: args.title,
+            parentConversationId,
+            // Inherit as a copy: what the user already approved carries over, but the
+            // child saying "don't ask again" must not rewrite the parent's policy.
+            confirmationPreferences: options.confirmationPreferences
+                ? { skipConfirmationFor: new Set(options.confirmationPreferences.skipConfirmationFor) }
+                : undefined,
+            // Subscribed before the run starts. Subscribing afterwards would lose the
+            // result of a task that finishes quickly.
+            onEvent: createDelegatedRunWatcher(parentConversationId, user, args.title),
+        });
+
+        log.info({
+            childConversationId: result.conversationId,
+            parentConversationId,
+            queued: result.queued,
+            background: args.run_in_background !== false,
+        }, 'Delegated task started');
+
+        // Foreground: hold the turn and hand back the result, so "do this and tell me
+        // what you find" is one tool call rather than delegate-then-wait.
+        if (args.run_in_background === false) {
+            return await waitForTasks(
+                { conversation_ids: [result.conversationId], timeout_seconds: args.timeout_seconds },
+                { user, abortSignal: options.abortSignal, parentConversationId },
+            );
+        }
+
+        return {
+            compiled: JSON.stringify({
+                status: 'started',
+                conversation_id: result.conversationId,
+            }),
+        };
+    } catch (error) {
+        log.error({ err: error, parentConversationId }, 'Failed to delegate task');
+        return errorResult(error instanceof Error ? error.message : String(error));
+    }
+}
+
+/**
+ * Forward a delegated run's outcome to the conversation that started it.
+ *
+ * The final response is passed through in full - it is the point of the task. Progress
+ * is not forwarded; the parent can poll with inspect_task if it wants detail.
+ */
+function createDelegatedRunWatcher(
+    parentConversationId: string,
+    user: typeof User.$inferSelect,
+    title: string,
+): (event: ConversationEvent) => void {
+    let done = false;
+
+    return (event: ConversationEvent) => {
+        if (done) return;
+        const childConversationId = event.conversationId;
+
+        if (event.type === 'run_complete') {
+            done = true;
+            void deliverToParent({
+                parentConversationId,
+                user,
+                message: [
+                    `[Delegated task completed] ${title}`,
+                    `Conversation: ${childConversationId}`,
+                    '',
+                    event.data.response || '(no final response)',
+                ].join('\n'),
+            });
+        } else if (event.type === 'run_stopped') {
+            done = true;
+            const reason = event.error ? `${event.reason}: ${event.error}` : event.reason;
+            void deliverToParent({
+                parentConversationId,
+                user,
+                message: [
+                    `[Delegated task did not finish] ${title}`,
+                    `Conversation: ${childConversationId}`,
+                    `Reason: ${reason}`,
+                ].join('\n'),
+            });
+        } else if (event.type === 'confirmation_request') {
+            void deliverToParent({
+                parentConversationId,
+                user,
+                message: [
+                    `[Delegated task needs user input] ${title}`,
+                    `Conversation: ${childConversationId}`,
+                    `Waiting on: ${event.data.title}`,
+                ].join('\n'),
+            });
+        } else if (event.type === 'billing_error' || event.type === 'auth_error') {
+            // Nothing to report and nothing to retry - the parent would hit the same wall.
+            done = true;
+        }
+    };
+}
+
+/**
+ * Read another conversation. Returns immediately - tools in an iteration must all
+ * settle before the model sees any of them, so this must never wait on a run.
+ */
+export async function inspectTask(
+    args: InspectTaskArgs,
+    options: { user?: typeof User.$inferSelect },
+): Promise<DelegationResult> {
+    const { user } = options;
+    if (!user) return errorResult('Cannot inspect - no user context available');
+    if (!args?.conversation_id) return errorResult('conversation_id is required');
+
+    const conversation = await atifConversationService.getConversation(args.conversation_id);
+    if (!conversation || conversation.userId !== user.id) {
+        return errorResult(`Conversation ${args.conversation_id} not found`);
+    }
+
+    const detail = args.detail ?? 'latest';
+    const steps = conversation.trajectory.steps.filter(step => step.source !== 'system');
+    const status = describeStatus(args.conversation_id);
+    const header = [
+        `Conversation: ${args.conversation_id}`,
+        `Title: ${conversation.title ?? '(untitled)'}`,
+        `Status: ${status}`,
+    ];
+
+    if (detail === 'full') {
+        return {
+            compiled: [
+                ...header,
+                `Steps: ${steps.length}`,
+                '',
+                'Conversations can be long, rather than reading it all at once, query the local API and efficiently select just what you need.',
+                `Call GET /api/chat/${args.conversation_id}/history on your own server (default: http://localhost:6464).`,
+                'See the introspect skill for more details.',
+                '',
+                'Most recent steps:',
+                ...steps.slice(-3).map(describeStep),
+            ].join('\n'),
+        };
+    }
+
+    const lastStep = steps[steps.length - 1];
+    if (!lastStep) {
+        return { compiled: [...header, 'No steps yet.'].join('\n') };
+    }
+
+    // Once a task has finished, its final response is the answer - lead with it whole
+    // rather than with the mechanics of how it got there.
+    const isActive = getActiveStatus(args.conversation_id)?.isActive ?? false;
+    if (!isActive) {
+        const finalResponse = [...steps].reverse().find(s => s.source === 'agent' && s.message)?.message;
+        if (finalResponse) {
+            return { compiled: [...header, '', 'Final response:', finalResponse].join('\n') };
+        }
+    }
+
+    if (detail === 'latest') {
+        return { compiled: [...header, '', describeStep(lastStep)].join('\n') };
+    }
+
+    const lastUserIndex = steps.findLastIndex(s => s.source === 'user');
+    const turn = lastUserIndex >= 0 ? steps.slice(lastUserIndex) : steps.slice(-5);
+    return {
+        compiled: [
+            ...header,
+            '',
+            ...turn.map(describeStep).filter(Boolean),
+        ].join('\n\n'),
+    };
+}
+
+/** Default and ceiling for how long the agent will sit waiting on delegated work. */
+const DEFAULT_WAIT_SECONDS = 300;
+const MAX_WAIT_SECONDS = 1800;
+
+/**
+ * Block until delegated tasks finish, then return their results.
+ *
+ * Without this the agent has to keep taking a step to stay alive while work runs, and
+ * invents busywork to fill the time. Waiting is the honest thing to do when the next
+ * action genuinely depends on a result.
+ *
+ * The wait releases early if the run is stopped or the user sends a message, so it never
+ * traps the conversation.
+ */
+export async function waitForTasks(
+    args: WaitForTasksArgs,
+    options: { user?: typeof User.$inferSelect; abortSignal?: AbortSignal; parentConversationId?: string },
+): Promise<DelegationResult> {
+    const { user, abortSignal, parentConversationId } = options;
+    if (!user) return errorResult('Cannot wait - no user context available');
+
+    const ids = args?.conversation_ids ?? [];
+    if (ids.length === 0) return errorResult('conversation_ids is required');
+
+    const owned = await db.select({ id: Conversation.id, userId: Conversation.userId })
+        .from(Conversation)
+        .where(inArray(Conversation.id, ids));
+    const ownedIds = new Set(owned.filter(c => c.userId === user.id).map(c => c.id));
+    const unknown = ids.filter(id => !ownedIds.has(id));
+    if (unknown.length > 0) return errorResult(`Conversation(s) not found: ${unknown.join(', ')}`);
+
+    const timeoutMs = Math.min(
+        Math.max(args.timeout_seconds ?? DEFAULT_WAIT_SECONDS, 1),
+        MAX_WAIT_SECONDS,
+    ) * 1000;
+
+    // The results are handed straight to the model below, so don't also append them to
+    // this conversation and wake it again once the wait ends.
+    const release = parentConversationId ? suppressDeliveries(parentConversationId) : () => undefined;
+
+    // One controller decides when to stop waiting, so every per-task wait unwinds together.
+    const stopWaiting = new AbortController();
+    const giveUp = () => stopWaiting.abort();
+    const timer = setTimeout(giveUp, timeoutMs);
+    abortSignal?.addEventListener('abort', giveUp, { once: true });
+
+    // A user message mid-wait sets stopMode without aborting the run, so watch for it -
+    // otherwise the user would be stuck behind the timeout before being answered.
+    const watchInterrupt = setInterval(() => {
+        const activeRun = parentConversationId ? getBus(parentConversationId)?.activeRun : undefined;
+        if (activeRun && activeRun.stopMode !== 'none') giveUp();
+    }, 250);
+
+    try {
+        await Promise.all(ids.map(id => waitForOne(id, stopWaiting.signal)));
+    } finally {
+        clearTimeout(timer);
+        clearInterval(watchInterrupt);
+        abortSignal?.removeEventListener('abort', giveUp);
+        release();
+    }
+
+    const summaries = await Promise.all(ids.map(async id => {
+        const result = await inspectTask({ conversation_id: id, detail: 'latest' }, { user });
+        return result.compiled;
+    }));
+
+    return { compiled: summaries.join('\n\n---\n\n') };
+}
+
+/** Resolves when this conversation's run settles, or when the caller stops waiting. */
+function waitForOne(conversationId: string, stopWaiting: AbortSignal): Promise<void> {
+    const bus = getBus(conversationId);
+    if (!bus?.activeRun || stopWaiting.aborted) return Promise.resolve();
+
+    return new Promise<void>(resolve => {
+        let settled = false;
+        const finish = () => {
+            if (settled) return;
+            settled = true;
+            unsubscribe();
+            stopWaiting.removeEventListener('abort', finish);
+            resolve();
+        };
+
+        stopWaiting.addEventListener('abort', finish, { once: true });
+
+        const unsubscribe = bus.subscribe(event => {
+            if (
+                event.type === 'run_complete'
+                || event.type === 'run_stopped'
+                || event.type === 'billing_error'
+                || event.type === 'auth_error'
+            ) {
+                finish();
+            }
+        });
+    });
+}
+
+/** Hard stop a conversation's run. */
+export async function stopTask(
+    args: StopTaskArgs,
+    options: { user?: typeof User.$inferSelect },
+): Promise<DelegationResult> {
+    const { user } = options;
+    if (!user) return errorResult('Cannot stop - no user context available');
+    if (!args?.conversation_id) return errorResult('conversation_id is required');
+
+    const [conversation] = await db.select().from(Conversation).where(eq(Conversation.id, args.conversation_id));
+    if (!conversation || conversation.userId !== user.id) {
+        return errorResult(`Conversation ${args.conversation_id} not found`);
+    }
+
+    const stopped = stopConversationRun(args.conversation_id);
+    return {
+        compiled: stopped
+            ? `Stopped conversation ${args.conversation_id}.`
+            : `Conversation ${args.conversation_id} had no run in progress.`,
+    };
+}

--- a/src/server/processor/confirmation/confirmation.service.ts
+++ b/src/server/processor/confirmation/confirmation.service.ts
@@ -18,6 +18,15 @@ import {
 } from './confirmation.types';
 
 /**
+ * How long an unanswered confirmation blocks its run before it is given up on.
+ *
+ * A run can be waiting while nobody is at the machine - a scheduled routine at 3am, or
+ * a delegated task still going after the app was closed - so this is generous. Without
+ * it those runs would block forever.
+ */
+export const CONFIRMATION_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+
+/**
  * Callback function type for requesting confirmation from user
  * The implementer (WebSocket handler, TUI, etc.) provides this
  */

--- a/src/server/processor/conversation/atif/atif.service.ts
+++ b/src/server/processor/conversation/atif/atif.service.ts
@@ -5,7 +5,7 @@
 
 import { asc, eq, and, inArray, isNull, sql } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
-import { db } from '../../../db';
+import { db, getDefaultChatModel } from '../../../db';
 import { Conversation, ConversationStep, User } from '../../../db/schema';
 import { createEmptyATIFTrajectory } from './atif.types';
 import {
@@ -29,6 +29,8 @@ import {
 import { createChildLogger } from '../../../logger';
 
 const log = createChildLogger({ component: 'atif' });
+
+export type ConversationRole = 'manual' | 'delegated';
 
 export interface ConversationWithTrajectory {
   id: string;
@@ -200,6 +202,21 @@ export class ATIFConversationService {
     return withTrajectory(conversation, steps);
   }
 
+  /**
+   * Whether a conversation was delegated by an agent. Derived from the parent link
+   * rather than stored, so it can never disagree with its source.
+   */
+  async getConversationRole(
+    conversationId: string,
+    _user: typeof User.$inferSelect,
+  ): Promise<ConversationRole> {
+    const [conversation] = await db
+      .select({ parentConversationId: Conversation.parentConversationId })
+      .from(Conversation)
+      .where(eq(Conversation.id, conversationId));
+
+    return conversation?.parentConversationId ? 'delegated' : 'manual';
+  }
 
   /**
    * Adds a step to a conversation

--- a/src/server/processor/conversation/index.ts
+++ b/src/server/processor/conversation/index.ts
@@ -33,6 +33,7 @@ export async function sendMessageToModel(
     chatModelId?: number,
     runId?: string,
     onTextChunk?: (chunk: string) => void,
+    chatModelAlias?: string,
 ) {
     // Check for test mock (E2E tests inject this via preload)
     if (globalThis.__pipaliMockLLM) {
@@ -54,7 +55,8 @@ export async function sendMessageToModel(
         throw new Error('No chat model configured.');
     }
 
-    const modelName = chatModelWithApi.chatModel.friendlyName || chatModelWithApi.chatModel.name;
+    const requestedModelName = chatModelAlias ?? chatModelWithApi.chatModel.name;
+    const modelName = chatModelAlias ?? chatModelWithApi.chatModel.friendlyName ?? chatModelWithApi.chatModel.name;
     const aiModelApiName = chatModelWithApi.aiModelApi?.name || 'Device';
     const aiModelType = chatModelWithApi.chatModel.modelType;
     log.info({ model: modelName, provider: aiModelApiName }, 'Using model');
@@ -90,7 +92,7 @@ export async function sendMessageToModel(
             const response = await withTokenRefresh(async (token) => {
                 return sendMessageToGpt(
                     messages,
-                    chatModelWithApi.chatModel.name,
+                    requestedModelName,
                     token,
                     chatModelWithApi.aiModelApi?.apiBaseUrl,
                     tools,
@@ -145,6 +147,15 @@ export async function sendMessageToModel(
  * would need fake pricing, sync special-casing, and selector filtering.
  */
 export const PLATFORM_FAST_MODEL = 'pipali:fast';
+
+export type PlatformModelTier = 'flagship' | 'balanced' | 'lite';
+
+/** Model tier aliases resolved by the platform. */
+export const PLATFORM_TIER_MODELS = {
+    flagship: 'pipali:flagship',
+    balanced: 'pipali:balanced',
+    lite: 'pipali:lite',
+} as const satisfies Record<PlatformModelTier, string>;
 
 /**
  * One-shot utility call to the fastest model available: the platform's fast

--- a/src/server/processor/conversation/index.ts
+++ b/src/server/processor/conversation/index.ts
@@ -10,10 +10,12 @@ import { createChildLogger } from '../../logger';
 
 const log = createChildLogger({ component: 'llm' });
 
-// Test mock interface - set by E2E test preload scripts via globalThis
+// Test mock interface - set by E2E test preload scripts via globalThis.
+// `history` lets a scenario react to earlier tool results, e.g. feeding an id returned
+// by one tool call into the next.
 declare global {
     var __pipaliMockLLM:
-        | ((query: string, ctx?: { sessionId?: string }) => ResponseWithThought | Promise<ResponseWithThought>)
+        | ((query: string, ctx?: { sessionId?: string; history?: ATIFTrajectory }) => ResponseWithThought | Promise<ResponseWithThought>)
         | undefined;
 }
 
@@ -36,7 +38,7 @@ export async function sendMessageToModel(
     if (globalThis.__pipaliMockLLM) {
         const actualQuery = query || history?.steps?.findLast(s => s.source === 'user')?.message || '';
         log.debug({ query: actualQuery.substring(0, 50) }, 'Using mock LLM');
-        return globalThis.__pipaliMockLLM(actualQuery, { sessionId: history?.session_id });
+        return globalThis.__pipaliMockLLM(actualQuery, { sessionId: history?.session_id, history });
     }
 
     // Resolve model: use conversation's chatModelId if provided, otherwise user's default

--- a/src/server/processor/director/index.ts
+++ b/src/server/processor/director/index.ts
@@ -141,6 +141,8 @@ interface ResearchConfig {
     confirmationContext?: ConfirmationContext;
     // Chat model ID to use for this conversation (overrides user's default)
     chatModelId?: number;
+    // Row-less platform model alias to use while retaining the selected model's configuration
+    chatModelAlias?: string;
     // Unique ID of current research run
     runId?: string;
     // Step count when iteration threshold was first reached, for stable warning injection
@@ -764,6 +766,7 @@ async function pickNextTool(
             config.chatModelId,
             config.runId,
             config.onTextChunk,
+            config.chatModelAlias,
         );
 
         // Check if response is valid

--- a/src/server/processor/director/index.ts
+++ b/src/server/processor/director/index.ts
@@ -562,6 +562,11 @@ Write the brief as if to someone who cannot see this conversation, because they 
                     type: 'string',
                     description: 'The complete, standalone brief for the task, including what "done" looks like. The task sees only this.',
                 },
+                model_tier: {
+                    type: 'string',
+                    enum: ['flagship', 'balanced', 'lite'],
+                    description: 'Model intelligence tier for this task. Choose based on difficulty and cost; omit to use the same tier as this conversation.',
+                },
                 conversation_id: {
                     type: 'string',
                     description: 'Omit to start a new task. Pass the id of a task you already started to send it a follow-up, which reaches it even mid-work.',
@@ -1029,6 +1034,7 @@ async function executeTool(
                         parentConversationId: context?.conversationId,
                         confirmationPreferences: context?.confirmation?.preferences,
                         abortSignal: context?.abortSignal,
+                        parentChatModelId: context?.chatModelId,
                     },
                 );
                 return result.compiled;
@@ -1282,6 +1288,7 @@ export async function* research(config: ResearchConfig): AsyncGenerator<Research
             shownReminders,
             loadedMcpTools,
             user: config.user,
+            chatModelId: config.chatModelId,
             abortSignal: config.abortSignal,
         };
         iteration.toolResults = await executeToolsInParallel(iteration.toolCalls, executionContext, config.abortSignal);

--- a/src/server/processor/director/index.ts
+++ b/src/server/processor/director/index.ts
@@ -12,6 +12,17 @@ import { shellCommand, type ShellCommandArgs } from '../actor/shell_command';
 import { webSearch, type WebSearchArgs } from '../actor/search_web';
 import { readWebpage, type ReadWebpageArgs } from '../actor/read_webpage';
 import { askUser, type AskUserArgs } from '../actor/ask_user';
+import type { ConversationRole } from '../conversation/atif/atif.service';
+import {
+    delegateTask,
+    inspectTask,
+    stopTask,
+    waitForTasks,
+    type DelegateTaskArgs,
+    type InspectTaskArgs,
+    type StopTaskArgs,
+    type WaitForTasksArgs,
+} from '../actor/delegate_task';
 import { generateImage, type GenerateImageArgs } from '../actor/generate_image';
 import { emailUser, type EmailUserArgs } from '../actor/email_user';
 import { applyProviderToolSearch, applyToolDeferral, searchTools, SEARCH_TOOLS_TOOL_NAME, type SearchToolsArgs } from '../actor/search_tools';
@@ -138,6 +149,8 @@ interface ResearchConfig {
     isFirstEverConversation?: boolean;
     // Conversation ID for tools that need to reference the current conversation
     conversationId?: string;
+    // Whether this conversation may itself delegate
+    conversationRole?: ConversationRole;
     // Callback for real-time text delta streaming
     onTextChunk?: (chunk: string) => void;
     // MCP tools whose full schemas are advertised to the model (others are deferred behind search_tools)
@@ -523,6 +536,108 @@ Tips:
     },
 ];
 
+/** Held apart from builtInTools because which conversations get them varies by role. */
+const delegationTools: ToolDefinition[] = [
+    {
+        name: 'delegate_task',
+        description: `Hand a task to a separate conversation that works on it independently.
+
+Delegate when a task will take more than a few steps or can be parallelized.
+
+By default the task runs in the background: this returns immediately with its conversation id, you stay free to talk, and you are notified when it finishes. Set run_in_background to false when you have nothing useful to do until it is done - then this one call waits and returns the result.
+
+Start several background tasks to run them at once, then wait_for_tasks on all of them together.
+
+Write the brief as if to someone who cannot see this conversation, because they cannot - they get only what you send.`,
+        schema: {
+            type: 'object',
+            properties: {
+                title: {
+                    type: 'string',
+                    description: 'Short label for the task, shown to the user in the sidebar and task cards. A few words.',
+                },
+                message: {
+                    type: 'string',
+                    description: 'The complete, standalone brief for the task, including what "done" looks like. The task sees only this.',
+                },
+                conversation_id: {
+                    type: 'string',
+                    description: 'Omit to start a new task. Pass the id of a task you already started to send it a follow-up, which reaches it even mid-work.',
+                },
+                run_in_background: {
+                    type: 'boolean',
+                    description: 'Defaults to true. Set false to wait for the result and get it back from this call.',
+                },
+                timeout_seconds: {
+                    type: 'number',
+                    description: 'Only used when run_in_background is false. How long to wait before returning current state. Defaults to 300, maximum 1800.',
+                    minimum: 1,
+                    maximum: 1800,
+                },
+            },
+            required: ['title', 'message'],
+        },
+    },
+    {
+        name: 'inspect_task',
+        description: `Read any of the user's conversations - a task you delegated, or an earlier chat you want to recall.
+
+Once a task has finished, every detail level returns its complete final response, since that is the answer you were waiting for.
+
+Detail levels for a task still in progress:
+- "latest" (default): the most recent step. The cheap way to check on progress.
+- "outline": the current turn - any message, and which tools ran (names with a short identifying argument, never their output).
+- "full": a pointer plus recent steps. For a long conversation, follow the instructions it returns to query your own API and pull only the parts you need.`,
+        schema: {
+            type: 'object',
+            properties: {
+                conversation_id: { type: 'string', description: 'The conversation to read.' },
+                detail: {
+                    type: 'string',
+                    enum: ['latest', 'outline', 'full'],
+                    description: 'How much to return while a task is still running. Defaults to "latest".',
+                },
+            },
+            required: ['conversation_id'],
+        },
+    },
+    {
+        name: 'wait_for_tasks',
+        description: `Wait for delegated tasks to finish and get their results.
+Use this for tasks already running in the background. If you are starting a task you intend to wait for, pass run_in_background: false to delegate_task instead - that is one call rather than two.
+Pass every task you are waiting on in one call so they run concurrently. Tasks that have already finished return immediately.
+Returns each task's final response. The wait ends early if the user interrupts you or stops the run, and returns whatever state the tasks are in if it reaches the timeout.`,
+        schema: {
+            type: 'object',
+            properties: {
+                conversation_ids: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: 'Conversation ids of the tasks to wait for, as returned by delegate_task.',
+                },
+                timeout_seconds: {
+                    type: 'number',
+                    description: 'How long to wait before giving up and reporting current state. Defaults to 300, maximum 1800.',
+                    minimum: 1,
+                    maximum: 1800,
+                },
+            },
+            required: ['conversation_ids'],
+        },
+    },
+    {
+        name: 'stop_task',
+        description: 'Stop a running conversation, such as a delegated task that is no longer needed or has gone off track. The conversation stays readable afterwards.',
+        schema: {
+            type: 'object',
+            properties: {
+                conversation_id: { type: 'string', description: 'The conversation whose run should be stopped.' },
+            },
+            required: ['conversation_id'],
+        },
+    },
+];
+
 /**
  * Get all available tools including built-in tools and MCP tools.
  * When many MCP tools are connected, their schemas are deferred behind tool
@@ -530,7 +645,13 @@ Tips:
  * marked defer_loading); others get the app-side search_tools actor, where
  * only tools in `loadedMcpTools` are advertised in full.
  */
-async function getAllTools(loadedMcpTools: Set<string> = new Set(), providerToolSearch: ProviderToolSearchMode = 'off'): Promise<ToolDefinition[]> {
+async function getAllTools(
+    loadedMcpTools: Set<string> = new Set(),
+    providerToolSearch: ProviderToolSearchMode = 'off',
+    conversationRole: ConversationRole = 'manual',
+): Promise<ToolDefinition[]> {
+    // A delegated task does the work but cannot split it further.
+    const baseTools = conversationRole === 'delegated' ? builtInTools : [...builtInTools, ...delegationTools];
     try {
         const mcpTools = await getMcpToolDefinitions();
         const deferredMcpTools = providerToolSearch !== 'off'
@@ -539,10 +660,10 @@ async function getAllTools(loadedMcpTools: Set<string> = new Set(), providerTool
                 serverDescriptions: getMcpServerDescriptions(),
             })
             : applyToolDeferral(mcpTools, loadedMcpTools);
-        return [...builtInTools, ...deferredMcpTools];
+        return [...baseTools, ...deferredMcpTools];
     } catch (error) {
         log.error({ err: error }, 'Failed to load MCP tools');
-        return builtInTools;
+        return baseTools;
     }
 }
 
@@ -573,8 +694,13 @@ async function pickNextTool(
     const { currentDate, dayOfWeek, location, username, userContext, currentIteration = 0, maxIterations, thresholdStepCount } = config;
     const isLast = currentIteration >= maxIterations - 1;
 
-    // Get all tools (built-in + MCP)
-    const tools = await getAllTools(config.loadedMcpTools, config.providerToolSearch);
+    // Get all tools (built-in + delegation + MCP). A delegated task does its own work
+    // rather than splitting it further, so delegation is withheld there.
+    const tools = await getAllTools(
+        config.loadedMcpTools,
+        config.providerToolSearch,
+        config.conversationRole,
+    );
     const toolChoice = isLast ? 'none' : 'auto';
 
     const now = new Date();
@@ -892,6 +1018,43 @@ async function executeTool(
                 );
                 return result.compiled;
             }
+            case 'delegate_task': {
+                const result = await delegateTask(
+                    toolCall.arguments as DelegateTaskArgs,
+                    {
+                        user: context?.user,
+                        parentConversationId: context?.conversationId,
+                        confirmationPreferences: context?.confirmation?.preferences,
+                        abortSignal: context?.abortSignal,
+                    },
+                );
+                return result.compiled;
+            }
+            case 'inspect_task': {
+                const result = await inspectTask(
+                    toolCall.arguments as InspectTaskArgs,
+                    { user: context?.user },
+                );
+                return result.compiled;
+            }
+            case 'stop_task': {
+                const result = await stopTask(
+                    toolCall.arguments as StopTaskArgs,
+                    { user: context?.user },
+                );
+                return result.compiled;
+            }
+            case 'wait_for_tasks': {
+                const result = await waitForTasks(
+                    toolCall.arguments as WaitForTasksArgs,
+                    {
+                        user: context?.user,
+                        abortSignal: context?.abortSignal,
+                        parentConversationId: context?.conversationId,
+                    },
+                );
+                return result.compiled;
+            }
             default:
                 return `Unknown tool: ${toolCall.function_name}`;
         }
@@ -1115,6 +1278,8 @@ export async function* research(config: ResearchConfig): AsyncGenerator<Research
             runId: config.runId,
             shownReminders,
             loadedMcpTools,
+            user: config.user,
+            abortSignal: config.abortSignal,
         };
         iteration.toolResults = await executeToolsInParallel(iteration.toolCalls, executionContext, config.abortSignal);
 

--- a/src/server/processor/director/types.ts
+++ b/src/server/processor/director/types.ts
@@ -69,6 +69,8 @@ export interface ToolExecutionContext {
     loadedMcpTools?: Set<string>;
     /** Owner of this run, for tools that create or read other conversations */
     user?: typeof User.$inferSelect;
+    /** Concrete model backing this run, used to derive delegated model policy */
+    chatModelId?: number;
     /** Aborted when the run is stopped, so long-waiting tools can release and clean up */
     abortSignal?: AbortSignal;
 }

--- a/src/server/processor/director/types.ts
+++ b/src/server/processor/director/types.ts
@@ -3,6 +3,7 @@
 import type { Responses } from 'openai/resources/responses/responses';
 import type { ATIFMetrics, ATIFObservationResult, ATIFToolCall } from "../conversation/atif/atif.types";
 import type { ConfirmationContext } from "../confirmation";
+import type { User } from "../../db/schema";
 
 export interface ToolCall {
     name: string;
@@ -66,4 +67,8 @@ export interface ToolExecutionContext {
     shownReminders?: Set<string>;
     /** MCP tools whose full schemas are advertised to the model; search_tools and direct calls add to it */
     loadedMcpTools?: Set<string>;
+    /** Owner of this run, for tools that create or read other conversations */
+    user?: typeof User.$inferSelect;
+    /** Aborted when the run is stopped, so long-waiting tools can release and clean up */
+    abortSignal?: AbortSignal;
 }

--- a/src/server/processor/research-runner.ts
+++ b/src/server/processor/research-runner.ts
@@ -16,7 +16,7 @@
 
 import { User } from '../db/schema';
 import { research, ResearchPausedError } from './director';
-import { atifConversationService } from './conversation/atif/atif.service';
+import { atifConversationService, type ConversationRole } from './conversation/atif/atif.service';
 import { addStepToTrajectory } from './conversation/atif/atif.utils';
 import { maxIterations as defaultMaxIterations } from '../utils';
 import { loadUserContext } from '../user-context';
@@ -47,6 +47,8 @@ export interface ResearchRunnerOptions {
     chatModelId?: number;
     /** Unique ID of current research run */
     runId?: string;
+    /** Home, a delegated task, or an ordinary chat */
+    conversationRole?: ConversationRole;
     /** Callback when tool calls are about to start (before execution) */
     onToolCallStart?: (iteration: ResearchIteration) => void;
     /** Callback when an iteration completes (after execution) */
@@ -176,6 +178,7 @@ export async function* runResearchWithConversation(
         confirmationContext,
         chatModelId: options.chatModelId,
         conversationId,
+        conversationRole: options.conversationRole,
         runId,
         onTextChunk: onTextDelta,
     })) {

--- a/src/server/processor/research-runner.ts
+++ b/src/server/processor/research-runner.ts
@@ -45,6 +45,8 @@ export interface ResearchRunnerOptions {
     confirmationContext?: ConfirmationContext;
     /** Chat model ID to use for this conversation */
     chatModelId?: number;
+    /** Row-less platform model alias to use for this run */
+    chatModelAlias?: string;
     /** Unique ID of current research run */
     runId?: string;
     /** Home, a delegated task, or an ordinary chat */
@@ -177,6 +179,7 @@ export async function* runResearchWithConversation(
         abortSignal,
         confirmationContext,
         chatModelId: options.chatModelId,
+        chatModelAlias: options.chatModelAlias,
         conversationId,
         conversationRole: options.conversationRole,
         runId,

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -221,6 +221,7 @@ api.get('/conversations', async (c) => {
         updatedAt: Conversation.updatedAt,
         chatModelId: Conversation.chatModelId,
         automationId: Conversation.automationId,
+        parentConversationId: Conversation.parentConversationId,
         isPinned: Conversation.isPinned,
     })
     .from(Conversation)
@@ -344,6 +345,7 @@ api.get('/conversations', async (c) => {
             chatModelId: conv.chatModelId,
             isActive,
             isAutomation: !!conv.automationId,
+            parentConversationId: conv.parentConversationId,
             isPinned: conv.isPinned,
             latestReasoning,
             ...(matchSnippet !== undefined && { matchSnippet }),

--- a/src/server/routes/ws/commands/message.ts
+++ b/src/server/routes/ws/commands/message.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Command, CommandContext } from './index';
-import type { ClientMessage, MessageCommand, QueuedMessage } from '../message-types';
+import type { ClientMessage, MessageCommand } from '../message-types';
 import { createSession, createRunningState } from '../session-state';
 import { createEmptyPreferences } from '../../../processor/confirmation';
 import { db, getDefaultChatModel, getChatModelById } from '../../../db';
@@ -15,7 +15,8 @@ import { Conversation } from '../../../db/schema';
 import { eq } from 'drizzle-orm';
 import { atifConversationService } from '../../../processor/conversation/atif/atif.service';
 import { getBus } from '../../../events/conversation-event-bus';
-import { rejectAllConfirmations } from '../confirmation-manager';
+import { queueMessageOnActiveRun } from '../../../events/conversation-runs';
+import { resumeAutoStart } from '../../../events/parent-inbox';
 import { createChildLogger } from '../../../logger';
 
 const log = createChildLogger({ component: 'message-command' });
@@ -40,36 +41,25 @@ export const MessageCommandHandler: Command<MessageCommand> = {
             runId,
         }, 'New message received');
 
+        // The user is present again: unattended chains start over, and an earlier stop
+        // no longer holds the conversation back.
+        if (conversationId) resumeAutoStart(conversationId);
+
         // Check if there's an active run on the bus for this conversation
-        if (conversationId) {
-            const bus = getBus(conversationId);
-            if (bus?.activeRun) {
-                const runHandle = bus.activeRun;
+        if (conversationId && getBus(conversationId)?.activeRun) {
+            log.info({ conversationId, runId }, 'Soft interrupt: queuing message on bus');
 
-                log.info({ conversationId, runId }, 'Soft interrupt: queuing message on bus');
-
-                if (chatModelId !== undefined) {
-                    const selectedModel = await getChatModelById(chatModelId);
-                    if (!selectedModel) {
-                        ctx.sendError('Selected chat model not found', conversationId);
-                        return;
-                    }
-                    await db.update(Conversation).set({ chatModelId }).where(eq(Conversation.id, conversationId));
+            if (chatModelId !== undefined) {
+                const selectedModel = await getChatModelById(chatModelId);
+                if (!selectedModel) {
+                    ctx.sendError('Selected chat model not found', conversationId);
+                    return;
                 }
-
-                const queuedMessage: QueuedMessage = { runId, clientMessageId, message: userQuery, chatModelId };
-                runHandle.queuedMessages.push(queuedMessage);
-                runHandle.stopMode = 'soft';
-                runHandle.stopReason = 'soft_interrupt';
-
-                // If blocked on confirmation, abort to unblock
-                if (runHandle.pendingConfirmations.size > 0) {
-                    runHandle.stopMode = 'hard';
-                    runHandle.abortController.abort();
-                    rejectAllConfirmations(runHandle, 'Research interrupted');
-                }
-                return;
+                await db.update(Conversation).set({ chatModelId }).where(eq(Conversation.id, conversationId));
             }
+
+            queueMessageOnActiveRun(conversationId, { runId, clientMessageId, message: userQuery, chatModelId });
+            return;
         }
 
         // No active run — start a new one

--- a/src/server/routes/ws/commands/stop.ts
+++ b/src/server/routes/ws/commands/stop.ts
@@ -8,8 +8,8 @@
 import type { Command, CommandContext } from './index';
 import type { ClientMessage, StopCommand } from '../message-types';
 import { getBus } from '../../../events/conversation-event-bus';
-import { rejectAllConfirmations } from '../confirmation-manager';
-import { setSessionInactive } from '../../../sessions/activeSessionsStore';
+import { stopConversationRun, stopDelegatedChildren } from '../../../events/conversation-runs';
+import { suspendAutoStart } from '../../../events/parent-inbox';
 import { createChildLogger } from '../../../logger';
 
 const log = createChildLogger({ component: 'stop-command' });
@@ -45,15 +45,16 @@ export const StopCommandHandler: Command<StopCommand> = {
             runId: runHandle.runId,
         }, 'Hard stop requested');
 
-        runHandle.stopMode = 'hard';
-        runHandle.stopReason = 'user_stop';
-        runHandle.queuedMessages = [];
-        runHandle.abortController.abort();
-        rejectAllConfirmations(runHandle, 'Research stopped');
+        // Before stopping: the cascade below makes each child report that it did not
+        // finish, and an unattended conversation wakes to relay that.
+        suspendAutoStart(conversationId);
+        stopConversationRun(conversationId);
 
-        // Immediately mark as inactive so refresh/observe sees no active run.
-        // The run-executor will call these again when it catches the abort — both are idempotent.
-        setSessionInactive(conversationId);
-        bus.activeRun = null;
+        // Stopping is the user's only handle on work Pipali started on its own, so it
+        // reaches delegated children too. Soft interrupts and normal completion do not.
+        const stoppedChildren = await stopDelegatedChildren(conversationId);
+        if (stoppedChildren.length > 0) {
+            log.info({ conversationId, stoppedChildren }, 'Stopped delegated children');
+        }
     },
 };

--- a/src/server/routes/ws/confirmation-manager.ts
+++ b/src/server/routes/ws/confirmation-manager.ts
@@ -14,6 +14,7 @@ import {
     type ConfirmationResponse,
     type ConfirmationCallback,
     CONFIRMATION_OPTIONS,
+    CONFIRMATION_TIMEOUT_MS,
 } from '../../processor/confirmation';
 import type { PendingConfirmation } from './message-types';
 import { createChildLogger } from '../../logger';
@@ -40,11 +41,29 @@ export function createConfirmationCallback(
 ): ConfirmationCallback {
     return async (request: ConfirmationRequest): Promise<ConfirmationResponse> => {
         return new Promise((resolve, reject) => {
+            // Nobody may be watching - a delegated task can still be going after the app
+            // is closed - so give up eventually rather than holding the run forever.
+            const timeout = setTimeout(() => {
+                if (!runHandle.pendingConfirmations.delete(request.requestId)) return;
+                log.warn({
+                    requestId: request.requestId,
+                    conversationId,
+                    runId: runHandle.runId,
+                }, 'Confirmation timed out');
+                reject(new Error('Confirmation timeout expired'));
+            }, CONFIRMATION_TIMEOUT_MS);
+
             runHandle.pendingConfirmations.set(request.requestId, {
                 requestId: request.requestId,
                 request,
-                resolve,
-                reject,
+                resolve: (response) => {
+                    clearTimeout(timeout);
+                    resolve(response);
+                },
+                reject: (error) => {
+                    clearTimeout(timeout);
+                    reject(error);
+                },
             });
 
             log.info({

--- a/src/server/routes/ws/message-types.ts
+++ b/src/server/routes/ws/message-types.ts
@@ -300,6 +300,8 @@ export interface QueuedMessage {
     clientMessageId: string;
     message: string;
     chatModelId?: number;
+    /** alias for dynamic selection by platform */
+    chatModelAlias?: string;
 }
 
 /**

--- a/src/server/skills/builtin/introspect/SKILL.md
+++ b/src/server/skills/builtin/introspect/SKILL.md
@@ -10,7 +10,7 @@ Get grounded answers about your capabilities and configuration - reference your 
 You run as a desktop app. Pipali code is open-source at https://github.com/khoj-ai/pipali. Stack: Tauri desktop shell (Rust) + Bun server (as tauri sidecar) + React frontend
 
 ## Query Live State
-Query your own API to answer questions about your current setup and manage state. You can use curl via `shell_command` or equivalent tools. Use `execution_mode: "direct"` if you hit sandbox restrictions.
+Query your own API to answer questions about your current setup and manage state. Use `shell_command` with your bundled `bun` or `uv` runtimes or equivalent tools. Use `execution_mode: "direct"` if you hit sandbox restrictions.
 
 See `references/api.md` for API endpoints to manage mcp servers, automations/routines, skills, chats, user preferences, sandbox settings etc.
 
@@ -18,6 +18,7 @@ See `references/api.md` for API endpoints to manage mcp servers, automations/rou
 The bun server is usually at: `http://localhost:6464`. If not, find your bun server url first.
 
 - What previous conversations have I had about surfing?: GET /api/conversations?q=surfing
+- What happened in a task I delegated?: GET /api/chat/<conversation_id>/history (or use `inspect_task`)
 - What tools are connected?:  GET /api/mcp/servers
 - What automations are set up?: GET /api/automations
 - What models are available?: GET /api/models
@@ -49,6 +50,7 @@ The app has a navigation sidebar on the left and a main content area.
 - New tasks/chats are started from the home page
 - Navigate by clicking the pipali name+icon on top pane of main content area
 - A live overview of all tasks being worked on, awaiting user confirmation, completed (but not yet viewed by user) or pinned by user is visible as task cards with progress indicators
+- Tasks you start with `delegate_task` appear as cards too, and their results come back to you as system messages
 
 ### Chat
 - Main body has chat history as rows of user message, trajectory dropdown, your message

--- a/src/server/skills/builtin/introspect/references/api.md
+++ b/src/server/skills/builtin/introspect/references/api.md
@@ -1,13 +1,17 @@
 # Pipali Self-Query API
 Default Base URL: `http://localhost:6464/api`. If not running there, find where the bun server is running yourself.
 
-Use curl via `shell_command` or equivalent tools. Use `execution_mode: "direct"` to query these endpoints if hit sandbox restrictions and to perform unsafe/modifying operations.
+Query these with `shell_command`, using the bundled `bun` or `uv` runtimes (both are always on PATH). Use `execution_mode: "direct"` if hit sandbox restrictions and to perform unsafe/modifying operations.
 
 ## Conversations
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/conversations` | List all conversations. Supports `?q=<term>` for full-text search |
+| GET | `/conversations` | List all conversations. Supports `?q=<term>` for full-text search. Each entry carries `parentConversationId` |
 | GET | `/chat/:conversationId/history` | Full message history and metadata like cost, tokens |
+
+Conversations you delegated have `parentConversationId` set to the conversation that
+started them. Read one with `inspect_task`, or pull just the parts you need from
+`/chat/:conversationId/history` when it is long.
 
 ## Models
 | Method | Endpoint | Description |

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Values the server and the client must agree on.
+ *
+ * Anything one side writes and the other reads back belongs here, declared as the
+ * writer and the reader together. Kept apart, a change to one leaves the other
+ * quietly parsing a format nobody produces any more.
+ */
+
+/** Leads every task summary, and is how a delegate step finds the task it started */
+export function formatConversationHeader(conversationId: string): string {
+    return `Conversation: ${conversationId}`;
+}
+
+export const CONVERSATION_HEADER =
+    /^Conversation: ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/im;

--- a/tests/client/thoughts-section.test.ts
+++ b/tests/client/thoughts-section.test.ts
@@ -1,5 +1,7 @@
 import { test, expect, describe } from 'bun:test';
 import { getCollapsedPreviewThoughts } from '../../src/client/components/thoughts/ThoughtsSection';
+import { getDelegatedConversationId } from '../../src/client/utils/formatting';
+import { formatConversationHeader } from '../../src/shared';
 import type { Thought } from '../../src/client/types';
 
 describe('collapsed thoughts preview', () => {
@@ -90,5 +92,26 @@ describe('collapsed thoughts preview', () => {
         expect(preview[2]?.type).toBe('tool_call');
         expect(preview[2]?.toolName).toBe('view_file');
         expect(preview[2]?.toolResult).toBeUndefined();
+    });
+});
+
+describe('delegated conversation link', () => {
+    const id = '3f2a1b4c-5d6e-4f70-8192-a3b4c5d6e7f8';
+
+    test('finds the conversation whether the task was backgrounded or waited on', () => {
+        // Backgrounded delegation reports as JSON
+        expect(getDelegatedConversationId('delegate_task', JSON.stringify({ status: 'started', conversation_id: id })))
+            .toBe(id);
+        // Delegation waited on in the foreground comes back as the inspect_task summary,
+        // built by the server. Parsing what it actually writes is what keeps the two in step.
+        expect(getDelegatedConversationId('delegate_task', `${formatConversationHeader(id)}\nTitle: Some task\nStatus: done`))
+            .toBe(id);
+    });
+
+    test('offers no link when there is no task to open', () => {
+        expect(getDelegatedConversationId('delegate_task', 'Error: Conversation not found')).toBeUndefined();
+        expect(getDelegatedConversationId('delegate_task', undefined)).toBeUndefined();
+        // Another tool naming a conversation is not a task this step started
+        expect(getDelegatedConversationId('inspect_task', `Conversation: ${id}`)).toBeUndefined();
     });
 });

--- a/tests/client/thoughts-section.test.ts
+++ b/tests/client/thoughts-section.test.ts
@@ -1,6 +1,11 @@
 import { test, expect, describe } from 'bun:test';
 import { getCollapsedPreviewThoughts } from '../../src/client/components/thoughts/ThoughtsSection';
-import { getDelegatedConversationId } from '../../src/client/utils/formatting';
+import {
+    buildDelegatedTaskTitleMap,
+    formatDelegationToolResult,
+    formatToolArgsRich,
+    getDelegatedConversationId,
+} from '../../src/client/utils/formatting';
 import { formatConversationHeader } from '../../src/shared';
 import type { Thought } from '../../src/client/types';
 
@@ -113,5 +118,72 @@ describe('delegated conversation link', () => {
         expect(getDelegatedConversationId('delegate_task', undefined)).toBeUndefined();
         // Another tool naming a conversation is not a task this step started
         expect(getDelegatedConversationId('inspect_task', `Conversation: ${id}`)).toBeUndefined();
+    });
+});
+
+describe('delegated task trajectory labels', () => {
+    const id = '3f2a1b4c-5d6e-4f70-8192-a3b4c5d6e7f8';
+    const delegationText = {
+        background: 'in background',
+        modelTier: (tier: string) => `to ${tier} model`,
+        waitForTasks: (tasks: string) => `on ${tasks}`,
+        noRunInProgress: 'No run was in progress.',
+    };
+
+    test('shows a selected model tier beside the delegated task title', () => {
+        const formatted = formatToolArgsRich('delegate_task', {
+            title: 'Review the proposal',
+            message: 'Review it carefully.',
+            model_tier: 'flagship',
+        }, false, undefined, undefined, delegationText);
+
+        expect(formatted?.text).toBe('Review the proposal');
+        expect(formatted?.secondary?.toLowerCase()).toContain('flagship');
+        expect(formatted?.secondary).toContain(delegationText.background);
+
+        const inherited = formatToolArgsRich('delegate_task', {
+            title: 'Review the proposal',
+            message: 'Review it carefully.',
+        }, false, undefined, undefined, delegationText);
+        expect(inherited?.secondary).toContain(delegationText.background);
+        expect(inherited?.secondary).not.toContain('model');
+    });
+
+    test('shows delegated task titles when waiting instead of conversation ids', () => {
+        const titles = buildDelegatedTaskTitleMap([{
+            type: 'tool_call',
+            toolName: 'delegate_task',
+            toolArgs: { title: 'Review the proposal' },
+            toolResult: JSON.stringify({ status: 'started', conversation_id: id }),
+        }]);
+
+        const formatted = formatToolArgsRich('wait_for_tasks', {
+            conversation_ids: [id],
+        }, false, undefined, titles, delegationText);
+
+        expect(formatted?.text).toContain('Review the proposal');
+        expect(formatted?.text).not.toContain(id);
+    });
+
+    test('drops redundant machine results and cleans useful summaries', () => {
+        const referencedId = '947d63f2-e63b-4a19-bae2-904d6a8bf89e';
+        expect(formatDelegationToolResult('delegate_task', JSON.stringify({
+            status: 'started',
+            conversation_id: id,
+        }))).toBeNull();
+
+        const formatted = formatDelegationToolResult('wait_for_tasks', [
+            formatConversationHeader(id),
+            'Title: Review the proposal',
+            'Status: completed or idle',
+            '',
+            'Final response:',
+            'The proposal looks good.',
+            formatConversationHeader(referencedId),
+        ].join('\n'));
+
+        expect(formatted).toContain('The proposal looks good.');
+        expect(formatted).not.toContain(id);
+        expect(formatted).toContain(referencedId);
     });
 });

--- a/tests/e2e/fixtures/mock-llm.ts
+++ b/tests/e2e/fixtures/mock-llm.ts
@@ -579,6 +579,155 @@ export function pubSubReloadReproScenario(): MockScenario {
 }
 
 /**
+ * Hands work to a separate conversation via delegate_task.
+ *
+ * The mock supplies only the tool call, so the real tool runs and a real delegated
+ * conversation is created. The delegated brief deliberately matches nothing but the
+ * catch-all, so the child finishes immediately.
+ */
+export function delegationScenario(): MockScenario {
+    return {
+        name: 'delegation',
+        queryPattern: '^delegate a task',
+        iterations: [
+            {
+                thought: 'This is self-contained, so I will hand it off and stay responsive.',
+                toolCalls: [
+                    {
+                        function_name: 'delegate_task',
+                        arguments: {
+                            title: 'Delegated task',
+                            message: 'Handle the sub-task and report back what you found.',
+                        },
+                        tool_call_id: 'tc-delegate-1',
+                    },
+                ],
+            },
+        ],
+        finalResponse: 'I started that in the background and will report back.',
+    };
+}
+
+/**
+ * Delegates work that keeps running, and holds its own final response open, so a test
+ * can act while both the parent and the delegated task are in flight.
+ */
+export function slowDelegationScenario(): MockScenario {
+    return {
+        name: 'slow-delegation',
+        queryPattern: '^delegate a slow task',
+        iterations: [
+            {
+                thought: 'Handing off a long-running piece of work.',
+                toolCalls: [
+                    {
+                        function_name: 'delegate_task',
+                        arguments: {
+                            title: 'Slow delegated task',
+                            // Long enough to still be running when the test presses stop,
+                            // short enough not to outlive the spec's cleanup.
+                            message: 'delegated slow work',
+                        },
+                        tool_call_id: 'tc-delegate-slow-1',
+                    },
+                ],
+            },
+        ],
+        finalResponse: 'The long task is under way.',
+        finalResponseDelayMs: 8000,
+    };
+}
+
+/**
+ * Starts two tasks at once, then waits on both together - the reason wait_for_tasks
+ * exists once run_in_background covers the single-task case.
+ */
+export function delegateTwoAndWaitScenario(): MockScenario {
+    return {
+        name: 'delegate-two-and-wait',
+        queryPattern: '^delegate two and wait',
+        iterations: [
+            {
+                thought: 'These are independent, so I will run them at the same time.',
+                toolCalls: [
+                    {
+                        function_name: 'delegate_task',
+                        arguments: { title: 'First parallel task', message: 'delegated slow work' },
+                        tool_call_id: 'tc-delegate-two-1',
+                    },
+                    {
+                        function_name: 'delegate_task',
+                        arguments: { title: 'Second parallel task', message: 'delegated slow work' },
+                        tool_call_id: 'tc-delegate-two-2',
+                    },
+                ],
+            },
+            {
+                thought: 'Both are running; waiting for them together.',
+                toolCalls: [
+                    {
+                        function_name: 'wait_for_tasks',
+                        // Preload fills in the ids the delegate calls returned.
+                        arguments: { conversation_ids: ['__DELEGATED_IDS__'], timeout_seconds: 60 },
+                        tool_call_id: 'tc-wait-two-1',
+                    },
+                ],
+            },
+        ],
+        finalResponse: 'Both parallel tasks finished.',
+    };
+}
+
+/**
+ * Delegates work it needs the answer to, in a single call. run_in_background: false
+ * holds the turn open and hands the result straight back.
+ */
+export function delegateAndWaitScenario(): MockScenario {
+    return {
+        name: 'delegate-and-wait',
+        queryPattern: '^delegate and wait',
+        iterations: [
+            {
+                thought: 'I need this answer before I can reply, so I will wait on it.',
+                toolCalls: [
+                    {
+                        function_name: 'delegate_task',
+                        arguments: {
+                            title: 'Awaited task',
+                            message: 'delegated slow work',
+                            run_in_background: false,
+                            timeout_seconds: 60,
+                        },
+                        tool_call_id: 'tc-delegate-wait-1',
+                    },
+                ],
+            },
+        ],
+        finalResponse: 'The delegated task finished and I waited for it.',
+    };
+}
+
+/** Work that runs for a few seconds, used as the body of a delegated task. */
+export function delegatedSlowWorkScenario(): MockScenario {
+    return {
+        name: 'delegated-slow-work',
+        queryPattern: '^delegated slow work',
+        iterations: Array.from({ length: 3 }, (_, i) => ({
+            thought: `Working through part ${i + 1}.`,
+            toolCalls: [
+                {
+                    function_name: 'list_files',
+                    arguments: { path: '.', pattern: '*' },
+                    tool_call_id: `tc-delegated-work-${i + 1}`,
+                },
+            ],
+        })),
+        finalResponse: 'The delegated work is done.',
+        iterationDelayMs: 1000,
+    };
+}
+
+/**
  * Default scenarios used in tests
  */
 export const defaultMockScenarios: MockScenario[] = [
@@ -600,6 +749,11 @@ export const defaultMockScenarios: MockScenario[] = [
     readFileScenario(),
     multiToolScenario(),
     pubSubReloadReproScenario(),
+    delegationScenario(),
+    slowDelegationScenario(),
+    delegatedSlowWorkScenario(),
+    delegateAndWaitScenario(),
+    delegateTwoAndWaitScenario(),
 ];
 
 /**

--- a/tests/e2e/helpers/cleanup.ts
+++ b/tests/e2e/helpers/cleanup.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import type { APIRequestContext, Page } from '@playwright/test';
 import { HomePage, ChatPage } from './page-objects';
 import { Selectors } from './selectors';
 
@@ -8,6 +8,49 @@ import { Selectors } from './selectors';
  * E2E tests share a single server process; runs continue even if the page that started them is closed.
  * This helper prevents state leakage (active tasks + confirmation toasts) into later tests.
  */
+/**
+ * Stop every conversation the server still reports as active.
+ *
+ * Home's task cards only show what this browser context knows about, which misses runs
+ * an agent started on its own. This drives cleanup from the server's own list instead,
+ * so delegated work can't leak into the next spec.
+ */
+export async function stopAllActiveConversations(
+    page: Page,
+    request: APIRequestContext,
+    opts?: { maxPasses?: number },
+): Promise<void> {
+    const chatPage = new ChatPage(page);
+    let quietPasses = 0;
+
+    for (let pass = 0; pass < (opts?.maxPasses ?? 20); pass++) {
+        const res = await request.get('/api/conversations');
+        if (!res.ok()) return;
+        const { conversations } = await res.json() as { conversations: { id: string; isActive?: boolean }[] };
+        const active = conversations.filter(c => c.isActive);
+
+        if (active.length === 0) {
+            // A completed task can wake its parent, which may start more work, so a single
+            // quiet reading isn't enough - wait for it to stay quiet.
+            if (++quietPasses >= 2) return;
+            await page.waitForTimeout(1500);
+            continue;
+        }
+
+        quietPasses = 0;
+        for (const conversation of active) {
+            await chatPage.gotoConversation(conversation.id);
+            try {
+                await chatPage.stopButton.waitFor({ state: 'visible', timeout: 3000 });
+                await chatPage.stopButton.click();
+                await chatPage.waitForIdle();
+            } catch {
+                // Finished on its own between listing and opening.
+            }
+        }
+    }
+}
+
 export async function stopAllActiveRunsFromHome(page: Page, opts?: { maxPasses?: number }): Promise<void> {
     const maxPasses = opts?.maxPasses ?? 10;
     const homePage = new HomePage(page);
@@ -17,15 +60,29 @@ export async function stopAllActiveRunsFromHome(page: Page, opts?: { maxPasses?:
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await homePage.waitForConnection();
 
+    const activeSelector = `${Selectors.taskCard}.running, ${Selectors.taskCard}.needs-input`;
+
     for (let pass = 0; pass < maxPasses; pass++) {
-        const activeCard = page.locator(`${Selectors.taskCard}.running, ${Selectors.taskCard}.needs-input`).first();
-        const activeCount = await page.locator(`${Selectors.taskCard}.running, ${Selectors.taskCard}.needs-input`).count();
+        const activeCount = await page.locator(activeSelector).count();
         if (activeCount === 0) return;
 
-        const cardTitle = ((await activeCard.locator('.task-card-title').textContent()) || '').trim();
+        // A run can finish on its own between the count above and the reads below,
+        // which flips the card to .completed so this locator no longer matches.
+        // That card needs no stopping, so re-check instead of waiting it out.
+        const activeCard = page.locator(activeSelector).first();
+        const cardTitle = await activeCard
+            .locator('.task-card-title')
+            .textContent({ timeout: 2000 })
+            .then(text => (text || '').trim())
+            .catch(() => null);
+        if (cardTitle === null) continue;
 
         // Toasts can overlap task cards; trigger click via DOM to avoid pointer interception flakes.
-        await activeCard.evaluate((el: HTMLElement) => el.click());
+        try {
+            await activeCard.evaluate((el: HTMLElement) => el.click(), undefined, { timeout: 2000 });
+        } catch {
+            continue;
+        }
         await chatPage.waitForConnection();
 
         // If a confirmation is pending, resolve it so it doesn't leak into later tests.

--- a/tests/e2e/mock-preload.ts
+++ b/tests/e2e/mock-preload.ts
@@ -9,7 +9,41 @@
 import { findMatchingScenario, defaultMockScenarios, type MockScenario } from './fixtures/mock-llm';
 import type { ResponseWithThought } from '../../src/server/processor/conversation/conversation';
 
-type MockCtx = { sessionId?: string };
+type MockCtx = { sessionId?: string; history?: { steps?: Array<{ observation?: { results?: Array<{ content?: unknown }> } }> } };
+
+/**
+ * Placeholder a scenario can put in tool arguments to reference every conversation id
+ * that earlier delegate_task calls returned in this turn.
+ */
+const DELEGATED_IDS = '__DELEGATED_IDS__';
+
+function findDelegatedConversationIds(ctx?: MockCtx): string[] {
+    const ids: string[] = [];
+    for (const step of ctx?.history?.steps ?? []) {
+        for (const result of step?.observation?.results ?? []) {
+            if (typeof result.content !== 'string') continue;
+            try {
+                const parsed = JSON.parse(result.content);
+                if (parsed?.conversation_id) ids.push(parsed.conversation_id as string);
+            } catch {
+                // Not a delegate result.
+            }
+        }
+    }
+    return ids;
+}
+
+/** Swap the placeholder for real ids, so a scenario can wait on what it started. */
+function resolveToolArguments(args: Record<string, unknown>, ctx?: MockCtx): Record<string, unknown> {
+    const ids = args.conversation_ids;
+    if (!Array.isArray(ids) || !ids.includes(DELEGATED_IDS)) return args;
+
+    const delegated = findDelegatedConversationIds(ctx);
+    return {
+        ...args,
+        conversation_ids: ids.flatMap(id => (id === DELEGATED_IDS ? delegated : [id])),
+    };
+}
 
 // Track mock state per session+scenario+query so multiple conversations can run concurrently.
 const scenarioState = new Map<string, { currentIteration: number }>();
@@ -108,7 +142,7 @@ function getMockResponse(query: string, ctx?: MockCtx): ResponseWithThought | Pr
             id: tc.tool_call_id,
             call_id: tc.tool_call_id,
             name: tc.function_name,
-            arguments: JSON.stringify(tc.arguments),
+            arguments: JSON.stringify(resolveToolArguments(tc.arguments as Record<string, unknown>, ctx)),
         })),
         thought: iteration.thought,
     };

--- a/tests/e2e/specs/delegation.e2e.ts
+++ b/tests/e2e/specs/delegation.e2e.ts
@@ -1,0 +1,218 @@
+/**
+ * Delegation Tests
+ *
+ * Pipali can hand a bounded task to a separate conversation that works on it in the
+ * background. The task is a normal conversation marked with a parent, and its result
+ * comes back to the parent as a system message.
+ */
+
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { ChatPage } from '../helpers/page-objects';
+import { Selectors } from '../helpers/selectors';
+import { stopAllActiveConversations, stopAllActiveRunsFromHome } from '../helpers/cleanup';
+
+type ConversationRow = {
+    id: string;
+    title: string;
+    parentConversationId?: string | null;
+    isActive?: boolean;
+};
+
+async function listConversations(request: APIRequestContext): Promise<ConversationRow[]> {
+    const res = await request.get('/api/conversations');
+    return (await res.json()).conversations as ConversationRow[];
+}
+
+async function childrenOf(request: APIRequestContext, parentId: string): Promise<ConversationRow[]> {
+    const all = await listConversations(request);
+    return all.filter(c => c.parentConversationId === parentId);
+}
+
+async function countTaskUpdates(request: APIRequestContext, conversationId: string): Promise<number> {
+    const res = await request.get(`/api/chat/${conversationId}/history`);
+    const { history } = await res.json() as {
+        history: Array<{ source: string; extra?: { kind?: string } }>;
+    };
+    return history.filter(s => s.source === 'system' && s.extra?.kind === 'delegated_task_update').length;
+}
+
+/** Final responses, one per completed run - so an extra one means an extra run. */
+async function countAgentResponses(request: APIRequestContext, conversationId: string): Promise<number> {
+    const res = await request.get(`/api/chat/${conversationId}/history`);
+    const { history } = await res.json() as {
+        history: Array<{ source: string; message?: string; tool_calls?: unknown[] }>;
+    };
+    return history.filter(s => s.source === 'agent' && !!s.message && !s.tool_calls?.length).length;
+}
+
+/** Send a query from a fresh chat and return that conversation's id. */
+async function delegateFrom(chatPage: ChatPage, query: string): Promise<string> {
+    await chatPage.goto();
+    await chatPage.sendMessage(query);
+    return await chatPage.waitForConversationId();
+}
+
+test.describe('Delegation', () => {
+    test.afterEach(async ({ page, request }) => {
+        // Delegated work runs in conversations this context never opened, so clean up
+        // from the server's active list rather than only Home's task cards.
+        await stopAllActiveConversations(page, request);
+        await stopAllActiveRunsFromHome(page);
+    });
+
+    test('delegating creates a child conversation linked to its parent', async ({ page, request }) => {
+        const chatPage = new ChatPage(page);
+        const parentId = await delegateFrom(chatPage, 'delegate a task');
+
+        // The parent answers immediately rather than blocking on the task.
+        await expect(page.locator(Selectors.assistantMessage).last())
+            .toContainText('background', { timeout: 15000 });
+
+        await expect.poll(
+            async () => (await childrenOf(request, parentId)).length,
+            { timeout: 15000, message: 'expected a delegated child conversation' },
+        ).toBeGreaterThan(0);
+
+        const children = await childrenOf(request, parentId);
+        expect(children[0]!.title).toBe('Delegated task');
+    });
+
+    test('the delegated result comes back to the parent as a system step', async ({ page, request }) => {
+        const chatPage = new ChatPage(page);
+        const parentId = await delegateFrom(chatPage, 'delegate a task');
+
+        await expect.poll(
+            () => countTaskUpdates(request, parentId),
+            { timeout: 30000, message: 'expected a delegated task update on the parent' },
+        ).toBeGreaterThan(0);
+
+        const { history } = await (await request.get(`/api/chat/${parentId}/history`)).json();
+        const update = history.find((s: { source: string; extra?: { kind?: string } }) =>
+            s.source === 'system' && s.extra?.kind === 'delegated_task_update');
+
+        // The child's final response is passed through whole - it is the point of the task.
+        expect(update.message).toContain('[Delegated task completed]');
+        expect(update.message).toContain('This is a mock response for testing.');
+    });
+
+    test('unattended delegation chains are bounded', async ({ page, request }) => {
+        const chatPage = new ChatPage(page);
+        const parentId = await delegateFrom(chatPage, 'delegate a task');
+
+        // Each completion wakes the parent, and this mock re-delegates every time it
+        // wakes. The auto-start depth guard is what stops that from running away.
+        await page.waitForTimeout(15000);
+
+        const children = await childrenOf(request, parentId);
+        expect(children.length).toBeGreaterThan(0);
+        expect(children.length).toBeLessThanOrEqual(5);
+    });
+
+    test('a foreground task holds the turn in a single call, then answers', async ({ page, request }) => {
+        const chatPage = new ChatPage(page);
+        // run_in_background: false - delegate and wait are one tool call, not two.
+        const parentId = await delegateFrom(chatPage, 'delegate and wait');
+
+        // The turn stays open across the delegated work rather than ending early and
+        // filling the gap with unrelated steps.
+        await expect(page.locator(Selectors.assistantMessage).last())
+            .toContainText('waited for it', { timeout: 30000 });
+
+        // Exactly one task was started - waiting is not polling.
+        expect((await childrenOf(request, parentId)).length).toBe(1);
+
+        // The result came back through the call, so no separate wake-up update was
+        // appended for the same task.
+        expect(await countTaskUpdates(request, parentId)).toBe(0);
+    });
+
+    test('several background tasks can be waited on together', async ({ page, request }) => {
+        const chatPage = new ChatPage(page);
+        const parentId = await delegateFrom(chatPage, 'delegate two and wait');
+
+        await expect(page.locator(Selectors.assistantMessage).last())
+            .toContainText('Both parallel tasks finished', { timeout: 40000 });
+
+        // Both ran as children of the same parent, concurrently rather than in sequence.
+        expect((await childrenOf(request, parentId)).length).toBe(2);
+        expect(await countTaskUpdates(request, parentId)).toBe(0);
+    });
+
+    test('a user message releases the agent from waiting', async ({ page, request }) => {
+        const chatPage = new ChatPage(page);
+        await delegateFrom(chatPage, 'delegate and wait');
+
+        // Interrupt while it is blocked on the delegated task.
+        await expect.poll(async () => {
+            const all = await listConversations(request);
+            return all.some(c => c.title === 'Awaited task' && c.isActive);
+        }, { timeout: 20000, message: 'expected the awaited task to be running' }).toBe(true);
+
+        await chatPage.sendMessage('actually, never mind');
+
+        // The interruption is answered rather than sitting behind the wait timeout.
+        await expect(page.locator(Selectors.userMessage, { hasText: 'actually, never mind' }))
+            .toBeVisible({ timeout: 15000 });
+        await expect.poll(
+            () => chatPage.isProcessing(),
+            { timeout: 30000, message: 'expected the parent to finish the interrupting turn' },
+        ).toBe(false);
+    });
+
+    test('stopping a conversation also stops its running delegated tasks', async ({ page, request }) => {
+        const chatPage = new ChatPage(page);
+        // This scenario delegates long-running work and holds its own response open,
+        // so both the parent and the child are in flight when we press stop.
+        const parentId = await delegateFrom(chatPage, 'delegate a slow task');
+
+        await expect.poll(
+            async () => (await childrenOf(request, parentId)).length,
+            { timeout: 15000, message: 'expected a delegated child conversation' },
+        ).toBeGreaterThan(0);
+
+        const [child] = await childrenOf(request, parentId);
+        await expect.poll(async () => {
+            const all = await listConversations(request);
+            return all.find(c => c.id === child!.id)?.isActive ?? false;
+        }, { timeout: 15000, message: 'expected the delegated task to be running' }).toBe(true);
+
+        await chatPage.stopTask();
+
+        // Stopping is the user's only handle on work Pipali started on its own.
+        await expect.poll(async () => {
+            const all = await listConversations(request);
+            return all.find(c => c.id === child!.id)?.isActive ?? false;
+        }, { timeout: 15000, message: 'expected the delegated task to stop with its parent' }).toBe(false);
+
+        // It stays readable afterwards.
+        const all = await listConversations(request);
+        expect(all.some(c => c.id === child!.id)).toBe(true);
+    });
+
+    test('a stopped conversation stays stopped when its tasks report back', async ({ page, request }) => {
+        const chatPage = new ChatPage(page);
+        const parentId = await delegateFrom(chatPage, 'delegate a slow task');
+
+        await expect.poll(
+            async () => (await childrenOf(request, parentId)).length,
+            { timeout: 15000, message: 'expected a delegated child conversation' },
+        ).toBeGreaterThan(0);
+
+        await chatPage.stopTask();
+        const responsesAtStop = await countAgentResponses(request, parentId);
+
+        // The cascade makes every child report that it did not finish. Relaying that would
+        // restart the conversation to narrate the stop the user just asked for.
+        await page.waitForTimeout(6000);
+        expect(await chatPage.isProcessing()).toBe(false);
+        expect(await countAgentResponses(request, parentId)).toBe(responsesAtStop);
+
+        // Stopping holds only until the user is back: this turn answers, and then a
+        // delegated result wakes the chat again on its own.
+        await chatPage.sendMessage('delegate a task');
+        await expect.poll(
+            () => countAgentResponses(request, parentId),
+            { timeout: 40000, message: 'expected a delegated result to wake the chat again' },
+        ).toBeGreaterThan(responsesAtStop + 1);
+    });
+});

--- a/tests/e2e/specs/delegation.e2e.ts
+++ b/tests/e2e/specs/delegation.e2e.ts
@@ -77,7 +77,7 @@ test.describe('Delegation', () => {
         expect(children[0]!.title).toBe('Delegated task');
     });
 
-    test('a delegated task shows in the sidebar while it runs', async ({ page }) => {
+    test('a delegated task stays out of the sidebar, and its step opens it', async ({ page }) => {
         const chatPage = new ChatPage(page);
         await chatPage.goto();
         // Delegate from a settled conversation: creating one refreshes the sidebar on its
@@ -87,13 +87,27 @@ test.describe('Delegation', () => {
 
         await chatPage.sendMessage('delegate a slow task');
 
-        // Nothing tells the client about a conversation Pipali created for itself, so the
-        // sidebar has to pick it up from the run starting - not from it finishing. Match on
-        // the title element: the parent's own row carries the same words in its subtitle.
+        // The task belongs to the conversation that started it, not to the sidebar's own list
         await expect(
-            page.locator(`${Selectors.conversationItemWithActiveTask} .conversation-title`)
+            page.locator(`${Selectors.conversationItem} .conversation-title`)
                 .filter({ hasText: /^Slow delegated task$/ }),
-        ).toBeVisible({ timeout: 15000 });
+        ).toHaveCount(0);
+
+        // The collapsed preview drops tool results, and the task's id comes from one, so
+        // the way in is the expanded trajectory - where step detail lives generally
+        await page.locator('.thoughts-toggle').first().click();
+
+        const delegateStep = page.locator('.thought-args-button').filter({ hasText: 'Slow delegated task' });
+        await expect(delegateStep).toBeVisible({ timeout: 15000 });
+
+        await delegateStep.click();
+        await expect(page.locator(`${Selectors.conversationItem}.active .conversation-title`))
+            .toHaveText('Slow delegated task', { timeout: 15000 });
+
+        // Going back leaves the task for the conversation that started it
+        await page.goBack();
+        await expect(page.locator(`${Selectors.conversationItem}.active .conversation-title`))
+            .not.toHaveText('Slow delegated task', { timeout: 15000 });
     });
 
     test('the delegated result comes back to the parent as a system step', async ({ page, request }) => {

--- a/tests/e2e/specs/delegation.e2e.ts
+++ b/tests/e2e/specs/delegation.e2e.ts
@@ -77,6 +77,25 @@ test.describe('Delegation', () => {
         expect(children[0]!.title).toBe('Delegated task');
     });
 
+    test('a delegated task shows in the sidebar while it runs', async ({ page }) => {
+        const chatPage = new ChatPage(page);
+        await chatPage.goto();
+        // Delegate from a settled conversation: creating one refreshes the sidebar on its
+        // own, which would hide whether the delegated task ever announces itself.
+        await chatPage.sendMessage('hello there');
+        await chatPage.waitForAssistantResponse();
+
+        await chatPage.sendMessage('delegate a slow task');
+
+        // Nothing tells the client about a conversation Pipali created for itself, so the
+        // sidebar has to pick it up from the run starting - not from it finishing. Match on
+        // the title element: the parent's own row carries the same words in its subtitle.
+        await expect(
+            page.locator(`${Selectors.conversationItemWithActiveTask} .conversation-title`)
+                .filter({ hasText: /^Slow delegated task$/ }),
+        ).toBeVisible({ timeout: 15000 });
+    });
+
     test('the delegated result comes back to the parent as a system step', async ({ page, request }) => {
         const chatPage = new ChatPage(page);
         const parentId = await delegateFrom(chatPage, 'delegate a task');

--- a/tests/e2e/specs/home-tasks.e2e.ts
+++ b/tests/e2e/specs/home-tasks.e2e.ts
@@ -6,7 +6,7 @@
 
 import { test, expect } from '@playwright/test';
 import { HomePage, ChatPage } from '../helpers/page-objects';
-import { stopAllActiveRunsFromHome } from '../helpers/cleanup';
+import { stopAllActiveConversations, stopAllActiveRunsFromHome } from '../helpers/cleanup';
 
 // Use "pausable" keyword to trigger slow mock scenario (1s between steps)
 const PAUSABLE_QUERY = 'run a pausable analysis';
@@ -18,7 +18,10 @@ function uniqueQuery(base: string): string {
 test.describe('Home Page Task Gallery', () => {
     let homePage: HomePage;
 
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page, request }) => {
+        // Specs share one server, and an agent can start work on its own, so begin from
+        // a known-quiet state rather than inheriting whatever is still running.
+        await stopAllActiveConversations(page, request);
         homePage = new HomePage(page);
         await homePage.goto();
     });

--- a/tests/server/delegate_task.test.ts
+++ b/tests/server/delegate_task.test.ts
@@ -1,5 +1,8 @@
 import { test, expect, describe } from 'bun:test';
-import { summarizeToolCall } from '../../src/server/processor/actor/delegate_task';
+import {
+    selectDelegatedModelAlias,
+    summarizeToolCall,
+} from '../../src/server/processor/actor/delegate_task';
 
 /**
  * inspect_task shows what a delegated task did, so it summarizes each tool call
@@ -48,5 +51,19 @@ describe('summarizeToolCall', () => {
     test('falls back to the name when the identifying argument is missing or blank', () => {
         expect(summarizeToolCall('grep_files', {})).toBe('grep_files');
         expect(summarizeToolCall('grep_files', { pattern: '   ' })).toBe('grep_files');
+    });
+});
+
+describe('selectDelegatedModelAlias', () => {
+    test('uses the tier explicitly selected by the parent model', () => {
+        expect(selectDelegatedModelAlias('lite', 'flagship')).toBe('pipali:lite');
+    });
+
+    test('defaults to the current conversation model tier', () => {
+        expect(selectDelegatedModelAlias(undefined, 'balanced')).toBe('pipali:balanced');
+    });
+
+    test('leaves models without a tier unaliased', () => {
+        expect(selectDelegatedModelAlias(undefined, null)).toBeUndefined();
     });
 });

--- a/tests/server/delegate_task.test.ts
+++ b/tests/server/delegate_task.test.ts
@@ -1,0 +1,52 @@
+import { test, expect, describe } from 'bun:test';
+import { summarizeToolCall } from '../../src/server/processor/actor/delegate_task';
+
+/**
+ * inspect_task shows what a delegated task did, so it summarizes each tool call
+ * down to one identifying argument. Payload-shaped arguments must never reach it - a file
+ * written by the child would otherwise be copied wholesale into the parent's context.
+ */
+describe('summarizeToolCall', () => {
+    test('identifies a write by file path, never its content', () => {
+        const summary = summarizeToolCall('write_file', {
+            file_path: '/tmp/pipali/report.md',
+            content: 'SECRET_PAYLOAD '.repeat(500),
+        });
+
+        expect(summary).toBe('write_file(/tmp/pipali/report.md)');
+        expect(summary).not.toContain('SECRET_PAYLOAD');
+    });
+
+    test('identifies a shell call by justification, never the command body', () => {
+        const summary = summarizeToolCall('shell_command', {
+            justification: 'Count the TypeScript files',
+            command: 'cat <<EOF > /tmp/script.sh\n' + 'echo LONG_SCRIPT_BODY\n'.repeat(200) + 'EOF',
+        });
+
+        expect(summary).toBe('shell_command(Count the TypeScript files)');
+        expect(summary).not.toContain('LONG_SCRIPT_BODY');
+    });
+
+    test('degrades unknown and MCP tools to name only', () => {
+        // MCP argument shapes are unbounded and unknowable, so nothing is echoed.
+        expect(summarizeToolCall('github__create_issue', {
+            title: 'Bug report',
+            body: 'HUGE_BODY '.repeat(500),
+        })).toBe('github__create_issue');
+
+        expect(summarizeToolCall('some_future_tool', { payload: 'x'.repeat(5000) }))
+            .toBe('some_future_tool');
+    });
+
+    test('truncates an identifying argument that is itself long', () => {
+        const summary = summarizeToolCall('search_web', { query: 'q'.repeat(1000) });
+
+        expect(summary.length).toBeLessThan(300);
+        expect(summary).toContain('…');
+    });
+
+    test('falls back to the name when the identifying argument is missing or blank', () => {
+        expect(summarizeToolCall('grep_files', {})).toBe('grep_files');
+        expect(summarizeToolCall('grep_files', { pattern: '   ' })).toBe('grep_files');
+    });
+});


### PR DESCRIPTION
## Why

Enable Pipali to delegate long or parallelizable tasks to separate
conversations. This keeps the parent conversation focused and lets
Pipali continue working with the user while delegated tasks run in
parallel in the background.

## What

```mermaid
sequenceDiagram
    actor User
    participant Parent as Parent conversation
    participant Task as Delegated conversation

    User->>Parent: Ask for long-running work
    Parent->>Task: delegate_task

    par Parent remains available
        Parent-->>User: Continue the conversation
    and Task runs independently
        Task->>Task: Work with its own model and trajectory
    end

    Task-->>Parent: Result as a system update
    Parent-->>User: Report the result
```

### Delegate Tasks to Background Conversations

- Create delegated tasks as normal conversations linked to their parent
- Reuse the existing conversation executor instead of adding a separate task runtime or registry
- Add tools to:
  - Start or continue a delegated task
  - Inspect task progress and results
  - Wait for multiple tasks together
  - Stop tasks that are no longer useful
- Run tasks in the background by default
   An optional foreground mode is available if the parent needs the result before continuing
- Prevent delegated conversations from delegating further

### Assign Model Tier for Delegated Tasks

- Let the parent choose a flagship, balanced, or lite model tier
- Default to the current conversation model's tier
- Use platform model aliases without creating synthetic model rows
- Preserve exact model selection for non-platform providers

### Report and Manage Task Results

- Return completed task results to the parent as system updates
- Wake idle parents and inject updates into active runs
- Coalesce and bound automatic wake-ups to prevent unattended loops
- Release task waits when the user sends a message or stops the run
- Avoid duplicate delivery when the parent is explicitly waiting
- Summarize inspected tool calls without copying large or sensitive payloads into the parent context

### Keep Delegated Work Under User Control

- Cascade a user hard stop to running delegated children
- Keep a hard-stopped parent idle until the user sends another message
- Let soft interrupts and normal completion leave children running
- Copy confirmation preferences to children without allowing them to modify the parent's preferences
- Time out unattended confirmation requests

### Tune the Delegated Task UX

- Discover conversations created server-side from their run_started events
- Keep delegated tasks out of the sidebar and Home by default
- Open a delegated conversation from the tool step that created it
- Show the task title and selected model tier in the trajectory
- Hide internal conversation IDs and redundant start or stop results
- Notify task completion through the parent instead of announcing the same result from both conversations
- Continue notifying when a delegated task needs user confirmation

### Test

- Add unit tests for task summaries, model-tier selection, and trajectory formatting
- Add end-to-end tests for foreground and background delegation, parallel waiting, result delivery, interrupts, bounded wake-ups, and stop behavior