### PR TITLE
Hand AppImage browser opens to the host xdg-open with a clean environment

### DIFF
--- a/scripts/appimage/xdg-open
+++ b/scripts/appimage/xdg-open
@@ -16,9 +16,17 @@
 #   without launching anything (khoj-ai/pipali#52),
 # - the browser gets the AppImage's GTK theme/backend/loader caches.
 
+# The colon lists below are split unquoted, so without -f a PATH or
+# LD_LIBRARY_PATH entry holding a glob character is expanded against the cwd.
+set -f
+
 # Shell builtins only: the host PATH this runs with may be minimal.
 case "$0" in */*) _self_dir="${0%/*}" ;; *) _self_dir="." ;; esac
 appdir="${APPDIR:-$(cd "$_self_dir/../.." && pwd)}"
+# A trailing slash would make the literal prefix match below miss every entry.
+while [ "$appdir" != "/" ] && [ "${appdir%/}" != "$appdir" ]; do
+    appdir="${appdir%/}"
+done
 
 # Drop every entry located under $appdir (and duplicates) from a colon list.
 strip_appdir_entries() {

--- a/scripts/appimage/xdg-open
+++ b/scripts/appimage/xdg-open
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Hand URL/file opening to the host's own xdg-open, outside the AppImage's
+# runtime environment. Installed by scripts/build-tauri.ts in place of the
+# xdg-open that Tauri's bundler copies from the CI build host
+# (tauri-apps/tauri#4265); that copy is kept next to this script as
+# xdg-open.bundled and only used when the host has no xdg-open at all.
+#
+# Why: everything the app spawns inherits the AppImage runtime environment.
+# AppRun prepends $APPDIR to PATH, LD_LIBRARY_PATH, XDG_DATA_DIRS, ... and the
+# GTK hook forces GTK_THEME, GDK_BACKEND and the module caches of the bundled
+# GTK. That is right for the app and wrong for anything the host is asked to
+# open on its behalf:
+# - host helpers crash on the bundled libraries (kde-open on Arch: libcurl
+#   symbol error; gio on Ubuntu 24.04 / Arch: glib symbol error),
+# - the build host's xdg-open predates Plasma 6, so on KDE it reports success
+#   without launching anything (khoj-ai/pipali#52),
+# - the browser gets the AppImage's GTK theme/backend/loader caches.
+
+# Shell builtins only: the host PATH this runs with may be minimal.
+case "$0" in */*) _self_dir="${0%/*}" ;; *) _self_dir="." ;; esac
+appdir="${APPDIR:-$(cd "$_self_dir/../.." && pwd)}"
+
+# Drop every entry located under $appdir (and duplicates) from a colon list.
+strip_appdir_entries() {
+    _list="$1" _out=""
+    _old_ifs="$IFS"; IFS=:
+    for _entry in $_list; do
+        case "$_entry" in
+            "$appdir" | "$appdir"/*) continue ;;
+        esac
+        case ":$_out:" in
+            *":$_entry:"*) continue ;;
+        esac
+        _out="${_out:+$_out:}$_entry"
+    done
+    IFS="$_old_ifs"
+    printf '%s' "$_out"
+}
+
+# Lists AppRun / the GTK hook prepend to: keep the host's original entries.
+for _var in PATH LD_LIBRARY_PATH XDG_DATA_DIRS PYTHONPATH PERLLIB GSETTINGS_SCHEMA_DIR \
+            QT_PLUGIN_PATH GST_PLUGIN_SYSTEM_PATH GST_PLUGIN_SYSTEM_PATH_1_0; do
+    eval "_value=\${$_var:-}"
+    [ -n "$_value" ] || continue
+    _cleaned=$(strip_appdir_entries "$_value")
+    if [ -n "$_cleaned" ]; then
+        eval "$_var=\$_cleaned"
+        export "$_var"
+    else
+        unset "$_var"
+    fi
+done
+[ -n "${PATH:-}" ] || PATH=/usr/local/bin:/usr/bin:/bin
+export PATH
+
+# AppRun runs the app from $APPDIR/usr; a browser started there keeps a cwd
+# inside a mount that disappears when the app quits. OWD is where the
+# AppImage was launched from.
+[ -d "${OWD:-}" ] && cd "$OWD"
+unset OLDPWD
+
+# Set outright for the bundled GTK/Python by AppRun and the GTK hook (the
+# original values are not preserved, so unsetting is the closest to the host's
+# own environment). APPIMAGE/APPDIR/ARGV0/OWD make AppImage-aware programs
+# believe *they* run from this AppImage.
+unset PYTHONHOME GTK_THEME GDK_BACKEND GTK_DATA_PREFIX GTK_EXE_PREFIX GTK_PATH \
+      GTK_IM_MODULE_FILE GDK_PIXBUF_MODULE_FILE GIO_EXTRA_MODULES \
+      APPIMAGE APPDIR ARGV0 OWD
+
+# First xdg-open on the (now host-only) PATH that is not this script.
+_host_xdg_open=""
+_old_ifs="$IFS"; IFS=:
+for _dir in $PATH; do
+    [ -n "$_dir" ] || continue
+    if [ -x "$_dir/xdg-open" ] && [ ! "$_dir/xdg-open" -ef "$0" ]; then
+        _host_xdg_open="$_dir/xdg-open"
+        break
+    fi
+done
+IFS="$_old_ifs"
+
+if [ -n "$_host_xdg_open" ]; then
+    exec "$_host_xdg_open" "$@"
+fi
+
+# No xdg-utils on the host: use the build host's copy, still with the cleaned
+# environment so whatever it launches is not broken by the bundle. Its own
+# helpers (xdg-mime) come from the bundle only as a last resort.
+_bundled="$_self_dir/xdg-open.bundled"
+if [ -x "$_bundled" ]; then
+    PATH="$PATH:$appdir/usr/bin"
+    export PATH
+    exec "$_bundled" "$@"
+fi
+
+echo "xdg-open: no xdg-open found on the host and no bundled fallback" >&2
+exit 3

--- a/scripts/build-tauri.ts
+++ b/scripts/build-tauri.ts
@@ -607,6 +607,51 @@ async function installPatchedGtkPlugin() {
 }
 
 /**
+ * Replace the bundled xdg-open with a hand-off to the host's own xdg-open.
+ *
+ * Tauri's bundler copies /usr/bin/xdg-open from the CI build host into the
+ * AppImage when the opener API is enabled (tauri-apps/tauri#4265), and AppRun
+ * puts AppDir/usr/bin first on PATH, so every "open in browser" in the app
+ * (Tauri opener plugin, the auth flows' Bun.spawn('xdg-open'), MCP OAuth)
+ * runs that ubuntu-22.04 copy inside the AppImage's runtime environment.
+ * Two things go wrong (khoj-ai/pipali#52):
+ * - xdg-utils 1.1.x predates Plasma 6: with KDE_SESSION_VERSION=6 its KDE
+ *   branch matches no case and reports success without launching anything,
+ *   so "Continue with Google" waits forever.
+ * - Whatever xdg-open launches inherits the AppImage's LD_LIBRARY_PATH, GTK
+ *   theme/backend and module caches: host helpers crash on the bundled
+ *   libraries (kde-open, gio: symbol lookup errors) and the browser gets the
+ *   bundled GTK setup.
+ * scripts/appimage/xdg-open strips the AppImage additions from the
+ * environment and execs the host's xdg-open, keeping the build host's copy
+ * (renamed xdg-open.bundled) only as a fallback for hosts without xdg-utils.
+ */
+async function installHostXdgOpenHandoff(extractRoot: string) {
+    const binDir = path.join(extractRoot, "usr", "bin");
+    const xdgOpen = path.join(binDir, "xdg-open");
+    const bundledFallback = path.join(binDir, "xdg-open.bundled");
+
+    const hasBundled = await fs
+        .access(xdgOpen)
+        .then(() => true)
+        .catch(() => false);
+    if (hasBundled) {
+        await fs.rename(xdgOpen, bundledFallback);
+    }
+    await fs.copyFile(path.join(ROOT_DIR, "scripts", "appimage", "xdg-open"), xdgOpen);
+    await fs.chmod(xdgOpen, 0o755);
+
+    // A hand-off that does not even parse would silently break every browser
+    // open in the AppImage; catch that at build time.
+    const checkProc = Bun.spawn(["sh", "-n", xdgOpen], { stdout: "ignore", stderr: "inherit" });
+    if ((await checkProc.exited) !== 0) throw new Error("Installed xdg-open hand-off failed to parse");
+
+    console.log(
+        `   Installed host xdg-open hand-off${hasBundled ? " (build-host copy kept as usr/bin/xdg-open.bundled)" : ""}`,
+    );
+}
+
+/**
  * Repack the produced AppImage with pristine sidecar binaries (bun, uv, uvx).
  *
  * Even with the GTK plugin patch above keeping linuxdeploy from crashing, the
@@ -688,6 +733,8 @@ async function repackAppImageWithPristineSidecars(debug: boolean, platform: Plat
         await fs.chmod(dst, 0o755);
         console.log(`   Restored pristine ${name}`);
     }
+
+    await installHostXdgOpenHandoff(extractRoot);
 
     // Without this verify step the build could regress to silently shipping a
     // corrupted bun again — the original symptom only surfaces at app launch.


### PR DESCRIPTION
## Problem

On KDE Plasma 6 (reported on Arch, #52) clicking **Continue with Google** in the AppImage never opens a browser and the app sits on *Waiting for authentication…* forever. The same mechanism degrades every "open in browser" from the AppImage on every distro, just less visibly.

## Root cause

Two layers, both in how the AppImage hands URLs to the host:

1. **The AppImage ships the build host's `xdg-open` and it shadows the host's.** Tauri's bundler copies `/usr/bin/xdg-open` from the CI runner into `usr/bin` when the opener API is enabled (tauri-apps/tauri#4265), and Tauri's `AppRun` puts `$APPDIR/usr/bin` first on `PATH` for the whole process tree. So every open path in the app — the Tauri opener plugin (`open` crate tries `xdg-open` first), `Bun.spawn(['xdg-open', url])` in `src/server/auth/oauth.ts`, and the MCP OAuth provider — runs the ubuntu-22.04 copy: **xdg-utils 1.1.3**. Its `open_kde` only knows `KDE_SESSION_VERSION` 4 and 5; with `6` the `case` matches nothing, `$?` is 0 and it calls `exit_success` **without launching anything**. The opener reports success, the UI switches to "Waiting for authentication", nothing ever comes back. xdg-utils fixed this in 1.2.0 (2024); current Arch ships 1.2.1, which the AppImage never gets to use.

2. **Whatever `xdg-open` launches inherits the AppImage runtime environment.** `AppRun` prepends `$APPDIR` to `LD_LIBRARY_PATH`, `PATH`, `XDG_DATA_DIRS`, `PYTHONPATH`, `PERLLIB`, `GSETTINGS_SCHEMA_DIR`, `QT_PLUGIN_PATH`, `GST_PLUGIN_SYSTEM_PATH(_1_0)`, `PYTHONHOME`, and the GTK hook forces `GTK_THEME`, `GDK_BACKEND=x11`, `GTK_PATH`, `GDK_PIXBUF_MODULE_FILE`, `GIO_EXTRA_MODULES`, … for the bundled GTK. Right for the app, wrong for host programs launched on its behalf:
   - Arch `kde-open` (kde-cli-tools 6.7.4): `symbol lookup error: /usr/lib/libcurl.so.4: undefined symbol: nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation` (bundled libnghttp2 shadows the host's)
   - Arch `gio`: `undefined symbol: g_unix_mount_entry_get_options`; Ubuntu 24.04 `gio`: `undefined symbol: g_string_free_and_steal` (bundled glib 2.72 vs host 2.80+)
   - the browser itself gets the bundled GTK theme, `GDK_BACKEND=x11`, and pixbuf/GTK module caches built for the bundled GTK.

   So even a host `xdg-open` that knows Plasma 6 would hand a broken environment to `kde-open`/`gio`/the browser.

## Fix

At the existing AppImage repack step, replace `usr/bin/xdg-open` with `scripts/appimage/xdg-open`, a small POSIX `sh` hand-off that:

- strips every `$APPDIR` entry (and duplicates) from the colon lists `AppRun` prepends to, keeping the host's own entries untouched (a user's own `LD_LIBRARY_PATH` survives, verified),
- unsets what the GTK hook sets outright for the bundled GTK (`GTK_THEME`, `GDK_BACKEND`, `GTK_PATH`, module caches, …) plus `APPIMAGE`/`APPDIR`/`ARGV0`/`OWD`, which make AppImage-aware programs believe *they* run from this AppImage,
- moves the cwd from `$APPDIR/usr` (where `AppRun` runs the app) back to the directory the AppImage was launched from (`OWD`), so the browser does not sit in a mount that disappears when the app quits,
- `exec`s the first `xdg-open` on the now host-only `PATH`,
- falls back to the build host's copy (kept as `usr/bin/xdg-open.bundled`, still with the cleaned environment, bundle `usr/bin` appended last so its `xdg-mime` is reachable) only when the host has no xdg-utils at all,
- uses shell builtins only, so it works with whatever minimal `PATH` the host has.

`build-tauri.ts` installs it right after the sidecar restore and `sh -n`-checks it, so a hand-off that does not parse fails the build instead of silently breaking every browser open.

Net effect: the AppImage opens URLs exactly the way the host's own `xdg-open` does — no better, no worse. (Ubuntu 24.04's xdg-utils is also 1.1.3 without the Plasma 6 case; that is the host's behavior for every app there, and out of scope here.)

## Testing

All runs A/B the released **0.8.0** AppDir against the same AppDir with this hand-off installed.

**Real app, real Arch userland, reporter's versions (xdg-utils 1.2.1, kde-cli-tools 6.7.4), `XDG_CURRENT_DESKTOP=KDE KDE_SESSION_VERSION=6`, synthetic click on *Continue with Google*, `kde-open` replaced by a logging stub:**

| | after the click |
|---|---|
| 0.8.0 (bundled `xdg-open` 1.1.3) | UI shows *Waiting for authentication…*, **nothing invoked** — #52 |
| with hand-off | UI shows *Waiting for authentication…*, `kde-open https://platform.pipali.ai/auth/oauth/google/authorize?redirect_uri=…&source=app&device_fingerprint=…` invoked, `GTK_THEME`/`GDK_BACKEND` unset, no `$APPDIR` entries in `PATH`/`LD_LIBRARY_PATH`, the user's own `LD_LIBRARY_PATH` entries preserved |

**Hand-off vs bundled script, same environment, real host tools:**

- bundled 1.1.3 + Plasma 6 env: `exit 0`, invokes nothing. Hand-off: host `xdg-open` 1.2.1 → `kde-open <url>`.
- real `/usr/bin/kde-open` reached through the hand-off: loads and runs (previously the libcurl symbol error above).
- host without xdg-utils (`/usr/bin` minus `xdg-open`): falls back to the bundled script with the cleaned environment; on a generic desktop it reaches `$BROWSER` with a clean `LD_LIBRARY_PATH`. On Plasma 6 *without* xdg-utils the 1.1.3 fallback still no-ops — the one residual case, and not a realistic Plasma install.

**Hand-off unit harness** (15 checks): byte-faithful reproduction of `AppRun`'s `PATH`/`LD_LIBRARY_PATH`/… formats plus sourcing the real GTK hook; asserts the host `xdg-open` receives the URL with no `$APPDIR` reference anywhere in its environment, original `PATH` order, user `LD_LIBRARY_PATH` kept, fallback selection, `$APPDIR` with spaces, `APPDIR` env absent (derived from `$0`), invocation by bare name from an unrelated cwd (how the `open` crate and `Bun.spawn` do it).

**Real `.AppImage` (repacked 0.8.0, real FUSE mount) on an Ubuntu 24.04 desktop**, a stub registered as the default `https` handler so it records what "the browser" receives, synthetic click on *Continue with Google*:

| | browser launched? | browser's environment |
|---|---|---|
| 0.8.0 | yes, correct OAuth URL | `LD_LIBRARY_PATH=/tmp/.mount_Pipali…/usr/lib/:…`, `GTK_THEME=Adwaita:light`, `GDK_BACKEND=x11`, `GDK_PIXBUF_MODULE_FILE` → bundle, `APPIMAGE=…`, cwd `/tmp/.mount_Pipali…/usr` — **18 references into the mount** |
| with hand-off | yes, same URL | user's own `LD_LIBRARY_PATH` only, `GTK_THEME`/`GDK_BACKEND`/pixbuf cache/`APPIMAGE` unset, cwd = launch directory — **0 references into the mount** |

(On GNOME/generic desktops the 1.1.3 copy does open a browser — that is why #52 is KDE-specific — but every launch carried the bundle's environment.)

- `bun build scripts/build-tauri.ts` clean; `sh -n` / `dash -n` clean on the hand-off.

## Not in scope

The same bundle-vs-host mismatch also spams `undefined symbol` warnings from host GIO modules (`libgvfscommon.so`, `libdconfsettings.so`) loaded into the bundled glib on every launch — a separate `GIO_MODULE_DIR` question, harmless to the auth flow, left alone here.

Fixes #52
