### PR TITLE
Guard the AppImage bundle/host boundary with the excludelist

### DIFF
--- a/scripts/build-tauri.ts
+++ b/scripts/build-tauri.ts
@@ -607,56 +607,139 @@ async function installPatchedGtkPlugin() {
 }
 
 /**
- * Strip the build host's libwayland-client from the extracted AppDir.
+ * Enforce the AppImage bundle/host boundary at repack.
  *
- * The linuxdeploy build Tauri's bundler uses deploys libwayland-client from
- * the build host into AppDir/usr/lib. At runtime the AppImage's AppRun
- * wrapper prepends AppDir/usr/lib to LD_LIBRARY_PATH for the whole process
- * tree, so the host's Mesa libEGL — which links libwayland-client and is
- * correctly NOT bundled, like libGL/libgbm/libdrm — resolves that SONAME to
- * the bundled copy instead of the host's own. When the target distro's Mesa
- * was built against a newer libwayland than the build host's (wayland 1.20 on
- * our ubuntu-22.04 CI), symbol resolution fails (e.g. current Arch/Fedora
- * Mesa needs wl_fixes_interface, added in wayland 1.24), no EGL display can
- * be created, and WebKitWebProcess aborts with `Could not create default EGL
- * display: EGL_BAD_PARAMETER` — a blank white window while the backend keeps
- * running (khoj-ai/pipali#21). The canonical AppImage excludelist mandates
- * leaving exactly this library system-provided: "New version of Mesa has some
- * dependency issues with libwayland-client if it is bundled". Any host that
- * can render the app already ships it, because host Mesa's libEGL itself
- * links it (verified on Ubuntu 24.04 / Debian 13 / Fedora and Arch current).
+ * AppRun prepends AppDir/usr/lib to LD_LIBRARY_PATH for the whole process
+ * tree, so a bundled library shadows the host's copy — including for host
+ * libraries loaded later into the same process. Anything coupled to the
+ * kernel driver, GPU or compositor therefore has to come from the host:
+ * bundling it freezes it at the build host's version (ubuntu-22.04) and
+ * breaks on every distro that has moved on. khoj-ai/pipali#21 is exactly
+ * that — host Mesa's libEGL binds the bundled wayland 1.20 libwayland-client
+ * instead of the host's, misses symbols current Mesa needs, and no EGL
+ * display can be created, so WebKitWebProcess aborts into a blank window.
  *
- * The other three bundled Wayland libraries deliberately stay bundled:
- * - libwayland-server: the bundled libwebkit2gtk links it, and current Mesa
- *   (Arch 26.2 / Fedora 26.1 / Ubuntu 24.04) does NOT link it anymore, so the
- *   host provides no guarantee it is installed — stripping it makes the app
- *   fail to start on hosts without it (verified on a minimal Fedora with
- *   working X11+Mesa). Keeping it is safe: the only host library that may
- *   bind it (Debian 13's Mesa) uses long-stable wayland-server ABI that the
- *   bundled 1.20 copy fully exports (symbol-diffed).
- * - libwayland-cursor / libwayland-egl: the bundled libgdk-3 needs them at
- *   load time (stripping them would add a new host package requirement), and
- *   they only call the wayland client library's stable, additive public ABI,
- *   so they work fine against the host's newer copy.
+ * scripts/linux/appimage-excludelist.txt is the canonical list of libraries
+ * on the host's side of that line. linuxdeploy applies it too, but bakes it
+ * into its binary at its own build time, and Tauri serves linuxdeploy from a
+ * static, unversioned tag on its own mirror - the same URL in every Tauri
+ * version, last refreshed 2024-07-29, while libwayland-client was excluded
+ * upstream on 2024-11-03. No Tauri upgrade moves that list for us.
+ *
+ * So rather than strip the escapee by name and wait for the next one to be
+ * reported as a bug, classify every excludelist library that reaches the
+ * AppDir: strip it, or record why we ship it anyway. An unclassified one
+ * fails the build, so a linuxdeploy or WebKitGTK bump cannot quietly change
+ * what we ship, and checkExcludelistDrift covers entries added upstream
+ * after our own snapshot.
  */
-const BUILD_HOST_WAYLAND_LIB_PREFIXES = ["libwayland-client.so"];
 
-async function stripBundledWaylandClient(extractRoot: string) {
-    const removed: string[] = [];
+/** Where scripts/linux/appimage-excludelist.txt is vendored from. */
+const EXCLUDELIST_UPSTREAM_URL =
+    "https://raw.githubusercontent.com/AppImageCommunity/pkg2appimage/master/excludelist";
+
+/** Excludelist libraries deleted from the AppDir so the host's copy wins. */
+const STRIP_FROM_BUNDLE: Record<string, string> = {
+    "libwayland-client.so": "host Mesa's libEGL binds this SONAME and needs symbols the build host's 1.20 copy lacks (#21)",
+};
+
+/**
+ * Excludelist libraries we ship anyway, with the reason the excludelist's
+ * rationale does not apply to us. Empty today: libwayland-client is the only
+ * excludelist entry that reaches the AppDir.
+ */
+const KEEP_BUNDLED: Record<string, string> = {};
+
+/** "libwayland-client.so.0.20.0" -> "libwayland-client.so"; null if not a shared library. */
+function sharedLibraryStem(fileName: string): string | null {
+    return /^(.+\.so)(?:\.\d+)*$/.exec(fileName)?.[1] ?? null;
+}
+
+function parseExcludelistStems(raw: string): Set<string> {
+    const stems = new Set<string>();
+    for (const line of raw.split("\n")) {
+        const entry = line.trim();
+        if (!entry || entry.startsWith("#")) continue;
+        const stem = sharedLibraryStem(entry);
+        if (stem) stems.add(stem);
+    }
+    return stems;
+}
+
+async function loadExcludelistStems(): Promise<Set<string>> {
+    const listPath = path.join(ROOT_DIR, "scripts", "linux", "appimage-excludelist.txt");
+    const stems = parseExcludelistStems(await Bun.file(listPath).text());
+    if (stems.size === 0) throw new Error(`No entries parsed from ${listPath}`);
+    return stems;
+}
+
+/**
+ * Fail the build when upstream has excluded a library we are still bundling.
+ *
+ * The vendored snapshot decides what gets stripped, so the artifact stays
+ * reproducible and offline builds keep working. Upstream is consulted only to
+ * answer the question the snapshot cannot: is our copy behind in a way that
+ * matters? A newly excluded library that is not in our bundle is a note to
+ * refresh the file; one that IS in our bundle is khoj-ai/pipali#21 happening
+ * again, so it stops the build. A fetch that does not land says nothing about
+ * us and is logged, not fatal.
+ */
+async function checkExcludelistDrift(bundled: Set<string>, vendored: Set<string>) {
+    let upstream: Set<string>;
+    try {
+        const resp = await fetch(EXCLUDELIST_UPSTREAM_URL, { signal: AbortSignal.timeout(15_000) });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        upstream = parseExcludelistStems(await resp.text());
+        if (upstream.size === 0) throw new Error("no entries parsed");
+    } catch (err) {
+        console.log(`   ⚠️  Could not compare the excludelist against upstream: ${err}`);
+        return;
+    }
+
+    const added = [...upstream].filter((stem) => !vendored.has(stem)).sort();
+    if (added.length === 0) return;
+
+    console.log(`   Vendored excludelist is behind upstream: ${added.join(", ")}`);
+    const bundledAndNew = added.filter((stem) => bundled.has(stem));
+    if (bundledAndNew.length > 0) {
+        throw new Error(
+            `Upstream excludes ${bundledAndNew.join(", ")}, which this AppDir still bundles. ` +
+            "Refresh scripts/linux/appimage-excludelist.txt and classify them in " +
+            "STRIP_FROM_BUNDLE or KEEP_BUNDLED in scripts/build-tauri.ts.",
+        );
+    }
+    console.log("   None of them are in this bundle; refresh the file when convenient");
+}
+
+async function enforceAppImageExcludelist(extractRoot: string) {
+    const excluded = await loadExcludelistStems();
+    const bundled = new Set<string>();
+    const stripped: string[] = [];
+    const kept = new Set<string>();
+    const unclassified = new Set<string>();
 
     async function walk(dir: string) {
-        // Directory may not exist in this AppDir layout (e.g. usr/lib64)
         const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => null);
-        if (!entries) return;
+        if (!entries) return; // layout-dependent: usr/lib64 may not exist
         for (const entry of entries) {
             const entryPath = path.join(dir, entry.name);
             if (entry.isDirectory()) {
-                // usr/lib/Pipali holds the app's own resources, never linuxdeploy libs
+                // usr/lib/Pipali holds the app's own resources, never linuxdeploy's libs
                 if (entry.name === "Pipali") continue;
                 await walk(entryPath);
-            } else if (BUILD_HOST_WAYLAND_LIB_PREFIXES.some((prefix) => entry.name.startsWith(prefix))) {
+                continue;
+            }
+            const stem = sharedLibraryStem(entry.name);
+            if (!stem) continue;
+            bundled.add(stem);
+            if (!excluded.has(stem)) continue;
+            if (KEEP_BUNDLED[stem]) {
+                kept.add(stem);
+            } else if (STRIP_FROM_BUNDLE[stem]) {
                 await fs.rm(entryPath, { force: true });
-                removed.push(path.relative(extractRoot, entryPath));
+                stripped.push(path.relative(extractRoot, entryPath));
+            } else {
+                unclassified.add(stem);
             }
         }
     }
@@ -664,12 +747,20 @@ async function stripBundledWaylandClient(extractRoot: string) {
     await walk(path.join(extractRoot, "usr", "lib"));
     await walk(path.join(extractRoot, "usr", "lib64"));
 
-    if (removed.length === 0) {
-        console.log("   No bundled libwayland-client found to strip");
+    for (const lib of stripped) {
+        console.log(`   Stripped ${lib} — ${STRIP_FROM_BUNDLE[sharedLibraryStem(path.basename(lib))!]}`);
     }
-    for (const lib of removed) {
-        console.log(`   Stripped bundled ${lib} (host provides it, see khoj-ai/pipali#21)`);
+    for (const stem of kept) console.log(`   Kept bundled ${stem} — ${KEEP_BUNDLED[stem]}`);
+    if (stripped.length === 0) console.log("   No excludelist libraries to strip");
+
+    if (unclassified.size > 0) {
+        throw new Error(
+            `AppDir bundles unclassified excludelist libraries: ${[...unclassified].sort().join(", ")}. ` +
+            "Add each to STRIP_FROM_BUNDLE or KEEP_BUNDLED in scripts/build-tauri.ts.",
+        );
     }
+
+    await checkExcludelistDrift(bundled, excluded);
 }
 
 /** 
@@ -801,7 +892,7 @@ async function repackAppImageWithPristineSidecars(debug: boolean, platform: Plat
     }
 
     await installHostXdgOpenHandoff(extractRoot);
-    await stripBundledWaylandClient(extractRoot);
+    await enforceAppImageExcludelist(extractRoot);
 
     // Without this verify step the build could regress to silently shipping a
     // corrupted bun again — the original symptom only surfaces at app launch.

--- a/scripts/linux/appimage-excludelist.txt
+++ b/scripts/linux/appimage-excludelist.txt
@@ -1,0 +1,254 @@
+# Vendored from https://github.com/AppImageCommunity/pkg2appimage/blob/master/excludelist
+# Fetched 2026-08-26. Refresh by re-downloading that file verbatim.
+#
+# The canonical list of libraries an AppImage must take from the host rather
+# than bundle. scripts/build-tauri.ts checks the AppDir against it at repack:
+# Tauri's pinned linuxdeploy applies an older snapshot, so entries added since
+# (libwayland-client, khoj-ai/pipali#21) still end up in our bundle.
+
+# This file lists libraries that we will assume to be present on the host system and hence
+# should NOT be bundled inside AppImages. This is a working document; expect it to change
+# over time. File format: one filename per line. Each entry should have a justification comment.
+
+# See the useful tool at https://abi-laboratory.pro/index.php?view=navigator&symbol=hb_buffer_set_cluster_level#result
+# to investigate issues with missing symbols.
+
+ld-linux.so.2
+ld-linux-x86-64.so.2
+libanl.so.1
+libBrokenLocale.so.1
+libcidn.so.1
+# libcrypt.so.1 # Not part of glibc anymore as of Fedora 30. See https://github.com/slic3r/Slic3r/issues/4798 and https://pagure.io/fedora-docs/release-notes/c/01d74b33564faa42959c035e1eee286940e9170e?branch=f28
+libc.so.6
+libdl.so.2
+libm.so.6
+libmvec.so.1
+# libnsl.so.1 # Not part of glibc anymore as of Fedora 28. See https://github.com/RPCS3/rpcs3/issues/5224#issuecomment-434930594
+libnss_compat.so.2
+# libnss_db.so.2 # Not part of neon-useredition-20190321-0530-amd64.iso
+libnss_dns.so.2
+libnss_files.so.2
+libnss_hesiod.so.2
+libnss_nisplus.so.2
+libnss_nis.so.2
+libpthread.so.0
+libresolv.so.2
+librt.so.1
+libthread_db.so.1
+libutil.so.1
+# These files are all part of the GNU C Library which should never be bundled.
+# List was generated from a fresh build of glibc 2.25.
+
+libstdc++.so.6
+# Workaround for:
+# usr/lib/libstdc++.so.6: version `GLIBCXX_3.4.21' not found
+
+libGL.so.1
+# The above may be missing on Chrome OS, https://www.reddit.com/r/Crostini/comments/d1lp67/ultimaker_cura_no_longer_running_as_an_appimage/
+libEGL.so.1
+# Part of the video driver (OpenGL); present on any regular
+# desktop system, may also be provided by proprietary drivers.
+# Known to cause issues if it's bundled.
+
+libGLdispatch.so.0
+libGLX.so.0
+# reported to be superfluent and conflicting system libraries (graphics driver)
+# see https://github.com/linuxdeploy/linuxdeploy/issues/89
+
+libOpenGL.so.0
+# Qt installed via install-qt.sh apparently links to this library
+# part of OpenGL like libGL/libEGL, so excluding it should not cause any problems
+# https://github.com/linuxdeploy/linuxdeploy/issues/152
+
+libdrm.so.2
+# Workaround for:
+# Antergos Linux release 2015.11 (ISO-Rolling)
+# /usr/lib/libdrm_amdgpu.so.1: error: symbol lookup error: undefined symbol: drmGetNodeTypeFromFd (fatal)
+# libGL error: unable to load driver: swrast_dri.so
+# libGL error: failed to load driver: swrast
+# Unrecognized OpenGL version
+
+libglapi.so.0
+# Part of mesa
+# known to cause problems with graphics, see https://github.com/RPCS3/rpcs3/issues/4427#issuecomment-381674910
+
+libgbm.so.1
+# Part of mesa
+# https://github.com/probonopd/linuxdeployqt/issues/390#issuecomment-529036305
+
+libxcb.so.1
+# Workaround for:
+# Fedora 23
+# symbol lookup error: /lib64/libxcb-dri3.so.0: undefined symbol: xcb_send_fd
+# Uncertain if this is required to be bundled for some distributions - if so we need to write a version check script and use LD_PRELOAD to load the system version if it is newer
+# Fedora 25:
+# undefined symbol: xcb_send_request_with_fds
+# https://github.com/AppImage/AppImages/issues/128
+
+libX11.so.6
+# Workaround for:
+# Fedora 23
+# symbol lookup error: ./lib/libX11.so.6: undefined symbol: xcb_wait_for_reply64
+# Uncertain if this is required to be bundled for some distributions - if so we need to write a version check script and use LD_PRELOAD to load the system version if it is newer
+
+libX11-xcb.so.1
+# https://github.com/probonopd/linuxdeployqt/issues/582
+# Uncertain if this is required to be bundled for some distributions - if so, please let us know
+
+libwayland-client.so.0
+# https://github.com/AppImageCommunity/pkg2appimage/pull/559
+# https://gitlab.freedesktop.org/mesa/mesa/-/issues/11316
+# New version of Mesa has some dependency issues with libwayland-client if it is bundled
+
+# --- Bundling GLib and its consequences ---
+# The following libraries need to be privately bundled, otherwise this error can happen:
+# - <AppDir>/usr/lib/x86_64-linux-gnu/libgnutls.so.30: version `GNUTLS_3_6_9' not found (required by /lib64/libglib-2.0.so.0)
+# See https://github.com/probonopd/Emacs.AppImage/issues/16
+# - /lib/x86_64-linux-gnu/libgio-2.0.so.0: undefined symbol: g_module_open_full
+# See https://github.com/AppImage/pkg2appimage/pull/500#issuecomment-997183221
+# libgio-2.0.so.0
+# libglib-2.0.so.0
+# libgmodule-2.0.so.0
+# libgobject-2.0.so.0
+# libgthread-2.0.so.0
+# NOTE: Privately bundling libglib-2.0.so.0 and libgobject-2.0.so.0 may break https://wiki.gnome.org/Projects/Libsecret,
+# see https://github.com/probonopd/linuxdeployqt/issues/544 for details
+# NOTE: Privately bundling libgio-2.0.so.0 can lead to this error on Ubuntu:
+# symbol lookup error: /usr/lib/x86_64-linux-gnu/gtk-2.0/modules/liboverlay-scrollbar.so: undefined symbol: g_settings_new
+
+# Since we bundle GLib (again), we have to bundle libpango to avoid undefined symbol: g_memdup2 etc.
+# see, e.g., https://github.com/TheAssassin/AppImageLauncher/issues/508
+# libpangoft2-1.0.so.0
+# libpangocairo-1.0.so.0
+# libpango-1.0.so.0
+# NOTE: Pango requires libharfbuzz >= 2.6.0 which isn't available on some older systems, so this error can happen:
+# libpango-1.0.so.0: undefined symbol: hb_ot_layout_get_horizontal_baseline_tag_for_script
+# See https://github.com/AppImageCommunity/pkg2appimage/issues/528
+
+# Commented as we currently bundle libpango
+# If libthai is bundled but libpango is not, this error can happen:
+# audacity: /tmp/.mount_AudaciUsFbON/usr/lib/libthai.so.0: version `LIBTHAI_0.1.25' not found (required by /usr/lib64/libpango-1.0.so.0)
+# on openSUSE Tumbleweed
+# libthai.so.0
+# If libcairo is bundled but libpango is not, this error can happen:
+# Can get symbol lookup error: /lib64/libpango-1.0.so.0: undefined symbol: g_log_structured_standard
+# --- Bundling GLib and its consequences ---
+
+# libgdk-x11-2.0.so.0 # Missing on openSUSE-Tumbleweed-KDE-Live-x86_64-Snapshot20170601-Media.iso
+# libgtk-x11-2.0.so.0 # Missing on openSUSE-Tumbleweed-KDE-Live-x86_64-Snapshot20170601-Media.iso
+
+libasound.so.2
+# Workaround for:
+# No sound, e.g., in VLC.AppImage (does not find sound cards)
+
+# https://github.com/AppImage/pkg2appimage/issues/475
+# libgdk_pixbuf-2.0.so.0
+# Was: Workaround for:
+# On Ubuntu, get (inkscape:25621): GdkPixbuf-WARNING **: Error loading XPM image loader: Image type 'xpm' is not supported
+
+libfontconfig.so.1
+# Workaround for:
+# Application stalls when loading fonts during application launch; e.g., KiCad on ubuntu-mate
+
+# other "low-level" font rendering libraries
+# should fix https://github.com/probonopd/linuxdeployqt/issues/261#issuecomment-377522251
+# and https://github.com/probonopd/linuxdeployqt/issues/157#issuecomment-320755694
+libfreetype.so.6
+libharfbuzz.so.0
+
+# Note, after discussion we do not exclude this, but we can use a dummy library that just does nothing
+# libselinux.so.1
+# Workaround for:
+# sed: error while loading shared libraries: libpcre.so.3: cannot open shared object file: No such file or directory
+# Some distributions, such as Arch Linux, do not come with libselinux.so.1 by default.
+# The solution is to bundle a dummy mock library:
+# echo "extern int is_selinux_enabled(void){return 0;}" >> selinux-mock.c
+# gcc -s -shared -o libselinux.so.1 -Wl,-soname,libselinux.so.1 selinux-mock.c
+# strip libselinux.so.1
+# More information: https://github.com/AppImage/AppImages/issues/83
+# and https://github.com/AppImage/AppImageKit/issues/775#issuecomment-614954821
+# https://gitlab.com/sulinos/devel/libselinux-dummy
+
+# The following are assumed to be part of the base system
+# Removing these has worked e.g., for Krita. Feel free to report if
+# you think that some of these should go into AppImages and why.
+libcom_err.so.2
+libexpat.so.1
+libgcc_s.so.1
+libgpg-error.so.0
+# libgssapi_krb5.so.2 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
+# libgssapi.so.3 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+# libhcrypto.so.4 # Missing on openSUSE LEAP 42.0
+# libheimbase.so.1 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+# libheimntlm.so.0 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+# libhx509.so.5 # Missing on openSUSE LEAP 42.0
+libICE.so.6
+# libidn.so.11 # Does not come with Solus by default
+# libk5crypto.so.3 # Running AppImage built on Debian 9 or Ubuntu 16.04 on an Archlinux fails otherwise; https://github.com/AppImage/AppImages/issues/301
+# libkeyutils.so.1 # Does not come with Void Linux by default; https://github.com/Subsurface-divelog/subsurface/issues/1971#issuecomment-466606834
+# libkrb5.so.26 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there. Missing on openSUSE LEAP 42.0
+# libkrb5.so.3 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
+# libkrb5support.so.0 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
+# libp11-kit.so.0 # https://github.com/AppImageCommunity/pkg2appimage/issues/547
+# libpcre.so.3 # Missing on Fedora 24, SLED 12 SP1, and openSUSE Leap 42.2
+# libroken.so.18 # Mission on openSUSE LEAP 42.0
+# libsasl2.so.2 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+libSM.so.6
+libusb-1.0.so.0
+libuuid.so.1
+# libwind.so.0 # Missing on openSUSE LEAP 42.0
+libz.so.1
+
+# Workaround for:
+# e.g., Spotify
+# relocation error: /lib/x86_64-linux-gnu/libgcrypt.so.20:
+# symbol gpgrt_lock_lock, version GPG_ERROR_1.0 not defined
+# in file libgpg-error.so.0 with link time reference
+libgpg-error.so.0
+
+libjack.so.0
+# it must match the ABI of the JACK server which is installed in the base system
+# rncbc confirmed this
+# However, this library is missing on Fedora-WS-Live-31-1-9
+# which means that we should avoid using JACK altogether if possible
+
+libpipewire-0.3.so.0
+# like libjack, it must match the ABI of the JACK server which is installed in the base system
+# https://github.com/linuxdeploy/linuxdeploy/issues/292
+
+# Unsolved issue:
+# https://github.com/probonopd/linuxdeployqt/issues/35
+# Error initializing NSS with a persistent database (sql:/home/me/.pki/nssdb): libsoftokn3.so: cannot open shared object file: No such file or directory
+# Error initializing NSS without a persistent database: NSS error code: -5925
+# nss_error=-5925, os_error=0
+# libnss3.so should not be removed from the bundles, as this causes other issues, e.g.,
+# https://github.com/probonopd/linuxdeployqt/issues/35#issuecomment-256213517
+# and https://github.com/AppImage/AppImages/pull/114
+# libnss3.so
+
+# The following cannot be excluded, see
+# https://github.com/AppImage/AppImages/commit/6c7473d8cdaaa2572248dcc53d7f617a577ade6b
+# http://stackoverflow.com/questions/32644157/forcing-a-binary-to-use-a-specific-newer-version-of-a-shared-library-so
+# libssl.so.1
+# libssl.so.1.0.0
+# libcrypto.so.1
+# libcrypto.so.1.0.0
+
+# According to https://github.com/RicardoEPRodrigues/3Engine/issues/4#issuecomment-511598362
+# libGLEW is not tied to a specific GPU. It's linked against libGL.so.1
+# and that one is different depending on the installed driver.
+# In fact libGLEW is changing its soversion very often, so you should always bundle libGLEW.so.2.0
+
+# libglut.so.3 # to be confirmed
+
+libxcb-dri3.so.0 # https://github.com/AppImage/AppImages/issues/348
+libxcb-dri2.so.0 # https://github.com/probonopd/linuxdeployqt/issues/331#issuecomment-442276277
+
+# If the next line turns out to cause issues, we will have to remove it again and find another solution
+libfribidi.so.0 # https://github.com/olive-editor/olive/issues/221 and https://github.com/knapsu/plex-media-player-appimage/issues/14
+
+# Workaround for:
+# symbol lookup error: /lib/x86_64-linux-gnu/libgnutls.so.30: undefined symbol: __gmpz_limbs_write
+# https://github.com/ONLYOFFICE/appimage-desktopeditors/issues/3
+# Apparently coreutils depends on it, so it should be safe to assume that it comes with every target system
+libgmp.so.10


### PR DESCRIPTION
## What

Replace the `libwayland-client` strip from #49 with a check of the whole AppDir against the canonical AppImage excludelist, at the same repack step.

- Vendor the canonical excludelist at `scripts/linux/appimage-excludelist.txt`. It decides what gets stripped, so builds stay reproducible and keep working offline.
- `STRIP_FROM_BUNDLE` deletes a library so the host's copy wins. `libwayland-client` is its only member, with the reason from #49.
- `KEEP_BUNDLED` records a library we ship despite the excludelist, and why. It's empty today.
- An excludelist library in neither list fails the build, so a linuxdeploy or WebKitGTK bump can't quietly change what we ship.
- On every Linux build the vendored list is also compared against upstream. A newly excluded library that is in our bundle fails the build; one that isn't is logged as a note to refresh the file. A fetch that doesn't land is logged, not fatal — upstream is only consulted for this comparison, never to decide what to strip.

`libwayland-cursor`, `-egl` and `-server` need no `KEEP_BUNDLED` entry — none of them is on the excludelist, so the reasoning @biztex worked out in #49 for keeping them bundled holds without having to be restated in code.

## Why

The excludelist is the canonical set of libraries an AppImage has to take from the host rather than bundle: anything coupled to the kernel driver, GPU or compositor. `AppRun` puts `AppDir/usr/lib` first on `LD_LIBRARY_PATH` for the whole process tree, so a bundled copy shadows the host's — including for host libraries loaded later into the same process. #21 was one entry off that list escaping into our bundle.

linuxdeploy does apply the list; it bakes it into its binary at its own build time (`src/core/generate-excludelist.sh`) and checks everything it deploys. But Tauri downloads linuxdeploy from a static, unversioned tag on its own mirror — `tauri-apps/binary-releases/releases/download/linuxdeploy/linuxdeploy-x86_64.AppImage`, the same URL in every Tauri version including current `dev` — and that asset was last refreshed **2024-07-29**. `libwayland-client` was added to the excludelist on **2024-11-03**. So we get a July-2024 view of the list, and it doesn't move when we upgrade Tauri.

That's visible in our own bundle: `libfontconfig`, `libfreetype` and `libharfbuzz` are correctly absent despite the GTK plugin force-deploying pango, while `libwayland-client` was not. Checking against the current list at repack covers the entries linuxdeploy's copy is too old to know about; the drift check covers entries added after our own snapshot.

## Testing

Against the AppImage CI built for #53 (run `32813653885`), extracted and inspected:

- Cross-referencing every bundled `.so` against the excludelist yields exactly one entry, `libwayland-client.so` — so `KEEP_BUNDLED` is genuinely empty and the strict check passes on today's bundle.
- Running the check against that AppDir removes exactly `usr/lib/libwayland-client.so.0` and nothing else.
- Diffing an earlier CI artifact of this branch (run `33037539900`) against #53's path-by-path: the only packaging difference is that one library. 200 → 199 shared libraries, GTK/WebKit/sidecars intact, `bun --version` still verified in the build log.

Drift check, all three paths, against the real extracted AppDir:

| vendored list | in bundle? | result |
|---|---|---|
| current | — | silent, build succeeds |
| missing `libwayland-client` | yes | build fails with the refresh instruction |
| missing `libfontconfig` | no | logged, build succeeds |

Also exercised against a synthetic AppDir covering the `usr/lib`, `usr/lib/x86_64-linux-gnu` and `usr/lib64` layouts, `.so.0` symlink plus `.so.0.20.0` realname pairs, and `usr/lib/Pipali/` app resources (skipped). `bunx tsc --noEmit` and `bun build scripts/build-tauri.ts` clean.

## Follow-up

Worth an upstream issue asking Tauri to refresh that linuxdeploy mirror — every Tauri Linux app currently ships the stale excludelist.
